### PR TITLE
入力欄のフォーカスによってヒントを切り替えできるようにした。

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -29,5 +29,6 @@ module.exports = {
     "react/jsx-uses-react": "off",
     "react/react-in-jsx-scope": "off",
     "react/jsx-no-comment-textnodes": "off",
+    "react/prop-types": "off",
   },
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -29,6 +29,5 @@ module.exports = {
     "react/jsx-uses-react": "off",
     "react/react-in-jsx-scope": "off",
     "react/jsx-no-comment-textnodes": "off",
-    "react/prop-types": "off",
   },
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,26 +2,29 @@ import { BrowserRouter, Route } from "react-router-dom";
 import { TopPage } from "./components/pages/TopPage";
 import { FormPage } from "./components/pages/FormPage";
 import { TitleBar } from "./components/common/TitleBar";
+import { HintProvider } from "./components/features/hint/HintProvider";
 
 function App() {
   return (
-    <BrowserRouter>
-      <Route exact path="/">
-        <TitleBar barType="nomal" formName="" />
-        <TopPage />
-      </Route>
-      <Route path="/learn">
-        <TitleBar barType="nomal" formName="" />
-        <p>学習ページがきます。</p>
-      </Route>
-      <Route path="/form">
-        <TitleBar barType="form" formName="サンプルフォーム" />
-        <FormPage />
-      </Route>
-      <Route path="/testTitle">
-        <TitleBar barType="nomal" formName="" />
-      </Route>
-    </BrowserRouter>
+    <HintProvider>
+      <BrowserRouter>
+        <Route exact path="/">
+          <TitleBar barType="nomal" formName="" />
+          <TopPage />
+        </Route>
+        <Route path="/learn">
+          <TitleBar barType="nomal" formName="" />
+          <p>学習ページがきます。</p>
+        </Route>
+        <Route path="/form">
+          <TitleBar barType="form" formName="サンプルフォーム" />
+          <FormPage />
+        </Route>
+        <Route path="/testTitle">
+          <TitleBar barType="nomal" formName="" />
+        </Route>
+      </BrowserRouter>
+    </HintProvider>
   );
 }
 

--- a/src/components/features/FormBase.tsx
+++ b/src/components/features/FormBase.tsx
@@ -2,7 +2,7 @@ import { Box, Grid } from "@mui/material";
 import { Hint } from "./hint/Hint";
 import { Form } from "./form/Form";
 
-interface FormData {
+/*interface FormData {
   stepName: string;
   hintList: HintList[];
 }
@@ -10,9 +10,10 @@ interface FormData {
 interface HintList {
   hint: string;
   explanation: string;
-}
+}*/
 
 export const FormBase = () => {
+  /*
   const formData: FormData[] = [
     {
       stepName: "ヘッダコメント",
@@ -104,18 +105,14 @@ export const FormBase = () => {
         },
       ],
     },
-  ];
+  ];*/
 
   return (
     <div>
       <Box>
         <Grid container spacing={2}>
           <Grid item xs={5}>
-            <Hint
-              stepNo={1}
-              stepName={formData[0].stepName}
-              hintList={formData[0].hintList}
-            />
+            <Hint />
           </Grid>
           <Grid item xs={7}>
             <Form />

--- a/src/components/features/form/Form.tsx
+++ b/src/components/features/form/Form.tsx
@@ -103,6 +103,7 @@ export const Form = () => {
             <FormProvider
               key={data.id}
               partType={data.partType}
+              explanation={data.explanation}
               childrenPart={data.childrenPart}
               inputData={data.inputData}
             />

--- a/src/components/features/form/FormProvider.tsx
+++ b/src/components/features/form/FormProvider.tsx
@@ -8,6 +8,7 @@ import { Main } from "./formComponents/Main";
 
 type Props = {
   partType: string;
+  explanation: string;
   childrenPart: string | FormData[];
   inputData: string;
 };
@@ -20,15 +21,25 @@ export const FormProvider = (props: Props) => {
       <Main partType={formData.partType} childrenPart={formData.childrenPart} />
     );
   } else if (formData.partType == "PROC") {
-    return <Process partType={formData.partType} />;
+    return (
+      <Process
+        partType={formData.partType}
+        explanation={formData.explanation}
+      />
+    );
   } else if (formData.partType == "FOR") {
     return (
-      <For partType={formData.partType} childrenPart={formData.childrenPart} />
+      <For
+        partType={formData.partType}
+        explanation={formData.explanation}
+        childrenPart={formData.childrenPart}
+      />
     );
   } else if (formData.partType == "WHL") {
     return (
       <While
         partType={formData.partType}
+        explanation={formData.explanation}
         childrenPart={formData.childrenPart}
       />
     );
@@ -36,6 +47,7 @@ export const FormProvider = (props: Props) => {
     return (
       <Function
         partType={formData.partType}
+        explanation={formData.explanation}
         childrenPart={formData.childrenPart}
       />
     );

--- a/src/components/features/form/formComponents/For.tsx
+++ b/src/components/features/form/formComponents/For.tsx
@@ -1,6 +1,8 @@
+import { useContext } from "react";
 import { FormData } from "../../../types/formData";
 import { FormProvider } from "../FormProvider";
 import { Process } from "./Process";
+import { HintContext } from "../../hint/HintProvider";
 
 type Props = {
   partType: string;
@@ -9,6 +11,12 @@ type Props = {
 };
 
 export const For = (props: Props) => {
+  const { setCurrentPartType } = useContext(HintContext);
+  const { setHintTypeC } = useContext(HintContext);
+
+  const partType = props.partType;
+  const explanation = props.explanation;
+
   const inputStyle = {
     fontSize: "16pt",
   };
@@ -29,11 +37,35 @@ export const For = (props: Props) => {
       <>
         <pre style={preStyle}>
           for {"("}
-          <input style={inputStyle} type="text" size={5} />
+          <input
+            style={inputStyle}
+            type="text"
+            size={5}
+            onFocus={() => {
+              setCurrentPartType(partType);
+              setHintTypeC(explanation);
+            }}
+          />
           {"; "}
-          <input style={inputStyle} type="text" size={5} />
+          <input
+            style={inputStyle}
+            type="text"
+            size={5}
+            onFocus={() => {
+              setCurrentPartType(partType);
+              setHintTypeC(explanation);
+            }}
+          />
           {"; "}
-          <input style={inputStyle} type="text" size={5} />
+          <input
+            style={inputStyle}
+            type="text"
+            size={5}
+            onFocus={() => {
+              setCurrentPartType(partType);
+              setHintTypeC(explanation);
+            }}
+          />
           {") {\n"}
         </pre>
         <div style={{ marginLeft: "50px" }}>

--- a/src/components/features/form/formComponents/For.tsx
+++ b/src/components/features/form/formComponents/For.tsx
@@ -4,6 +4,7 @@ import { Process } from "./Process";
 
 type Props = {
   partType: string;
+  explanation: string;
   childrenPart: string | FormData[];
 };
 
@@ -21,7 +22,7 @@ export const For = (props: Props) => {
     alert(
       "データ不正エラー：Forフォームの中には、少なくとも１つの子要素が必要です。"
     );
-    return <Process partType="PROC" />;
+    return <Process partType="PROC" explanation="" />;
   } else if (Array.isArray(props.childrenPart)) {
     const childrenPartArray: FormData[] = props.childrenPart;
     return (
@@ -42,6 +43,7 @@ export const For = (props: Props) => {
                 <FormProvider
                   key={childrenPart.id}
                   partType={childrenPart.partType}
+                  explanation={childrenPart.explanation}
                   childrenPart={childrenPart.childrenPart}
                   inputData={childrenPart.inputData}
                 />

--- a/src/components/features/form/formComponents/Function.tsx
+++ b/src/components/features/form/formComponents/Function.tsx
@@ -4,6 +4,7 @@ import { Process } from "./Process";
 
 type Props = {
   partType: string;
+  explanation: string;
   childrenPart: string | FormData[];
 };
 
@@ -21,7 +22,7 @@ export const Function = (props: Props) => {
     alert(
       "データ不正エラー：Functionフォームの中には、少なくとも１つの子要素が必要です。"
     );
-    return <Process partType="PROC" />;
+    return <Process partType="PROC" explanation="" />;
   } else if (Array.isArray(props.childrenPart)) {
     const childrenPartArray: FormData[] = props.childrenPart;
     return (
@@ -43,6 +44,7 @@ export const Function = (props: Props) => {
                 <FormProvider
                   key={childrenPart.id}
                   partType={childrenPart.partType}
+                  explanation={childrenPart.explanation}
                   childrenPart={childrenPart.childrenPart}
                   inputData={childrenPart.inputData}
                 />

--- a/src/components/features/form/formComponents/Function.tsx
+++ b/src/components/features/form/formComponents/Function.tsx
@@ -1,6 +1,8 @@
+import { useContext } from "react";
 import { FormData } from "../../../types/formData";
 import { FormProvider } from "../FormProvider";
 import { Process } from "./Process";
+import { HintContext } from "../../hint/HintProvider";
 
 type Props = {
   partType: string;
@@ -9,6 +11,12 @@ type Props = {
 };
 
 export const Function = (props: Props) => {
+  const { setCurrentPartType } = useContext(HintContext);
+  const { setHintTypeC } = useContext(HintContext);
+
+  const partType = props.partType;
+  const explanation = props.explanation;
+
   const inputStyle = {
     fontSize: "16pt",
   };
@@ -28,12 +36,53 @@ export const Function = (props: Props) => {
     return (
       <>
         <pre style={preStyle}>
-          <input style={inputStyle} type="text" size={5} />{" "}
-          <input style={inputStyle} type="text" size={5} /> {"(\n"}{" "}
-          <input style={inputStyle} type="text" size={5} />{" "}
-          <input style={inputStyle} type="text" size={5} />
+          <input
+            style={inputStyle}
+            type="text"
+            size={5}
+            onFocus={() => {
+              setCurrentPartType(partType);
+              setHintTypeC(explanation);
+            }}
+          />{" "}
+          <input
+            style={inputStyle}
+            type="text"
+            size={5}
+            onFocus={() => {
+              setCurrentPartType(partType);
+              setHintTypeC(explanation);
+            }}
+          />{" "}
+          {"(\n"}{" "}
+          <input
+            style={inputStyle}
+            type="text"
+            size={5}
+            onFocus={() => {
+              setCurrentPartType(partType);
+              setHintTypeC(explanation);
+            }}
+          />{" "}
+          <input
+            style={inputStyle}
+            type="text"
+            size={5}
+            onFocus={() => {
+              setCurrentPartType(partType);
+              setHintTypeC(explanation);
+            }}
+          />
           {",\n"} <input style={inputStyle} type="text" size={5} />{" "}
-          <input style={inputStyle} type="text" size={5} />
+          <input
+            style={inputStyle}
+            type="text"
+            size={5}
+            onFocus={() => {
+              setCurrentPartType(partType);
+              setHintTypeC(explanation);
+            }}
+          />
           {",\n"}
           {") {\n"}
         </pre>

--- a/src/components/features/form/formComponents/Process.tsx
+++ b/src/components/features/form/formComponents/Process.tsx
@@ -1,10 +1,27 @@
+import { useContext } from "react";
+import { HintContext } from "../../hint/HintProvider";
+
 type Props = {
   partType: string;
   explanation: string;
 };
 
 export const Process = (props: Props) => {
+  const { setCurrentPartType } = useContext(HintContext);
+  const { setHintTypeC } = useContext(HintContext);
+
   const partType = props.partType;
+  const explanation = props.explanation;
   console.log(partType); //理由：propsを受け取って使わないという事態を防ぐためにつけている
-  return <textarea cols={40} rows={4}></textarea>;
+  return (
+    <textarea
+      cols={40}
+      rows={4}
+      onFocus={() => {
+        setCurrentPartType(partType);
+        setHintTypeC(explanation);
+        console.log("切り替えます！");
+      }}
+    ></textarea>
+  );
 };

--- a/src/components/features/form/formComponents/Process.tsx
+++ b/src/components/features/form/formComponents/Process.tsx
@@ -1,5 +1,6 @@
 type Props = {
   partType: string;
+  explanation: string;
 };
 
 export const Process = (props: Props) => {

--- a/src/components/features/form/formComponents/Process.tsx
+++ b/src/components/features/form/formComponents/Process.tsx
@@ -12,7 +12,6 @@ export const Process = (props: Props) => {
 
   const partType = props.partType;
   const explanation = props.explanation;
-  console.log(partType); //理由：propsを受け取って使わないという事態を防ぐためにつけている
   return (
     <textarea
       cols={40}
@@ -20,7 +19,6 @@ export const Process = (props: Props) => {
       onFocus={() => {
         setCurrentPartType(partType);
         setHintTypeC(explanation);
-        console.log("切り替えます！");
       }}
     ></textarea>
   );

--- a/src/components/features/form/formComponents/While.tsx
+++ b/src/components/features/form/formComponents/While.tsx
@@ -4,6 +4,7 @@ import { Process } from "./Process";
 
 type Props = {
   partType: string;
+  explanation: string;
   childrenPart: string | FormData[];
 };
 
@@ -21,7 +22,7 @@ export const While = (props: Props) => {
     alert(
       "データ不正エラー：Forフォームの中には、少なくとも１つの子要素が必要です。"
     );
-    return <Process partType="PROC" />;
+    return <Process partType="PROC" explanation="" />;
   } else if (Array.isArray(props.childrenPart)) {
     const childrenPartArray: FormData[] = props.childrenPart;
     return (
@@ -38,6 +39,7 @@ export const While = (props: Props) => {
                 <FormProvider
                   key={childrenPart.id}
                   partType={childrenPart.partType}
+                  explanation={childrenPart.explanation}
                   childrenPart={childrenPart.childrenPart}
                   inputData={childrenPart.inputData}
                 />

--- a/src/components/features/form/formComponents/While.tsx
+++ b/src/components/features/form/formComponents/While.tsx
@@ -1,6 +1,8 @@
+import { useContext } from "react";
 import { FormData } from "../../../types/formData";
 import { FormProvider } from "../FormProvider";
 import { Process } from "./Process";
+import { HintContext } from "../../hint/HintProvider";
 
 type Props = {
   partType: string;
@@ -9,6 +11,12 @@ type Props = {
 };
 
 export const While = (props: Props) => {
+  const { setCurrentPartType } = useContext(HintContext);
+  const { setHintTypeC } = useContext(HintContext);
+
+  const partType = props.partType;
+  const explanation = props.explanation;
+
   const inputStyle = {
     fontSize: "16pt",
   };
@@ -29,7 +37,15 @@ export const While = (props: Props) => {
       <>
         <pre style={preStyle}>
           while {"("}
-          <input style={inputStyle} type="text" size={5} />
+          <input
+            style={inputStyle}
+            type="text"
+            size={5}
+            onFocus={() => {
+              setCurrentPartType(partType);
+              setHintTypeC(explanation);
+            }}
+          />
           {") {\n"}
         </pre>
         <div style={{ marginLeft: "50px" }}>

--- a/src/components/features/hint/Hint.tsx
+++ b/src/components/features/hint/Hint.tsx
@@ -25,7 +25,7 @@ interface HintData {
 
 export const Hint = () => {
   //ヒントのリスト（MainPageから渡された）
-  const { hintListIdx } = useContext(HintContext);
+  const { partType } = useContext(HintContext);
   const { hintTypeC } = useContext(HintContext);
 
   let hintData: HintData[] = [
@@ -92,11 +92,12 @@ export const Hint = () => {
     width: "100%",
   };
 
+  console.log(partType);
   console.log(hintTypeC);
 
   return (
     <Container maxWidth="md">
-      <Typography variant="h4">STEP{hintListIdx}: ステップ名</Typography>
+      <Typography variant="h4">STEP1: ステップ名</Typography>
       <Container maxWidth="md" sx={{ marginBottom: "30px" }}>
         <div>
           {hintList.map((hint, index) => {

--- a/src/components/features/hint/Hint.tsx
+++ b/src/components/features/hint/Hint.tsx
@@ -124,7 +124,7 @@ export const Hint = () => {
         setCurrentHintData(hint);
       }
     });
-  }, [hintTypeCIdx]);
+  }, [currentPartType]);
 
   const grammerCodeStyle = {
     backgroundColor: "#363636",

--- a/src/components/features/hint/Hint.tsx
+++ b/src/components/features/hint/Hint.tsx
@@ -28,6 +28,7 @@ export const Hint = (props: Props) => {
   const hintList: HintList[] = props.hintList;
   const stepName: string = props.stepName;
   const { hintListIdx } = useContext(HintContext);
+  const { hintTypeC } = useContext(HintContext);
 
   const grammerCodeStyle = {
     backgroundColor: "#363636",
@@ -35,6 +36,8 @@ export const Hint = (props: Props) => {
     color: "#fff",
     width: "100%",
   };
+
+  console.log(hintTypeC);
 
   return (
     <Container maxWidth="md">

--- a/src/components/features/hint/Hint.tsx
+++ b/src/components/features/hint/Hint.tsx
@@ -1,3 +1,6 @@
+import { useContext } from "react";
+import { HintContext } from "./HintProvider";
+
 import {
   Button,
   Container,
@@ -23,8 +26,8 @@ interface HintList {
 export const Hint = (props: Props) => {
   //ヒントのリスト（MainPageから渡された）
   const hintList: HintList[] = props.hintList;
-  const stepNo: number = props.stepNo;
   const stepName: string = props.stepName;
+  const { hintListIdx } = useContext(HintContext);
 
   const grammerCodeStyle = {
     backgroundColor: "#363636",
@@ -36,7 +39,7 @@ export const Hint = (props: Props) => {
   return (
     <Container maxWidth="md">
       <Typography variant="h4">
-        STEP{stepNo}: {stepName}
+        STEP{hintListIdx}: {stepName}
       </Typography>
       <Container maxWidth="md" sx={{ marginBottom: "30px" }}>
         <div>

--- a/src/components/features/hint/Hint.tsx
+++ b/src/components/features/hint/Hint.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useEffect, useState } from "react";
 import { HintContext } from "./HintProvider";
 
 import {
@@ -24,11 +24,20 @@ interface HintData {
 }
 
 export const Hint = () => {
-  //ヒントのリスト（MainPageから渡された）
   const { partType } = useContext(HintContext);
   const { hintTypeC } = useContext(HintContext);
 
   let hintData: HintData[] = [
+    {
+      partType: "DAMY",
+      partTitle: "ヒント非表示",
+      hintList: [
+        {
+          hintTitle: "つまずきに応じたヒントを出します",
+          hint: "ヒントの説明",
+        },
+      ],
+    },
     {
       partType: "PROC",
       partTitle: "計算・代入",
@@ -85,6 +94,19 @@ export const Hint = () => {
     },
   ];
 
+  //TypeCのヒントを展開するためのIdx
+  const [hintTypeCIdx] = useState<number>(0);
+  const [currentHintData, setCurrentHintData] = useState<HintData>(hintData[0]);
+
+  //partTypeの変更を検知し、それに合ったヒントをカレントなヒントデータとする
+  useEffect(() => {
+    hintData.map((hint) => {
+      if (hint.partType == partType) {
+        setCurrentHintData(hint);
+      }
+    });
+  }, [hintTypeCIdx]);
+
   const grammerCodeStyle = {
     backgroundColor: "#363636",
     fontSize: "14pt",
@@ -100,7 +122,7 @@ export const Hint = () => {
       <Typography variant="h4">STEP1: ステップ名</Typography>
       <Container maxWidth="md" sx={{ marginBottom: "30px" }}>
         <div>
-          {hintList.map((hint, index) => {
+          {currentHintData.hintList.map((hint, index) => {
             return (
               <Accordion key={hint.hint}>
                 <AccordionSummary
@@ -114,18 +136,8 @@ export const Hint = () => {
                   </Typography>
                 </AccordionSummary>
                 <AccordionDetails>
-                  <Typography variant="h6">for文の書き方</Typography>
-                  <textarea style={grammerCodeStyle} cols={40} rows={4}>
-                    {hint.explanation}
-                  </textarea>
-                  <br />
-                  <Typography variant="body1">
-                    カウンタ変数の初期化：何回目のループかをカウントする変数を初期化します。通常は0で初期化します。
-                    <br />
-                    継続条件：ループの中身に書く処理を、何の条件を満たす間行うかを条件式で設定します。
-                    <br />
-                    カウンタの増減：ループの中身の処理を一回実行した時に、カウンタ変数をどのように増減するかを設定します。通常は１つずつ増やすカウントアップを行います。
-                  </Typography>
+                  <Typography variant="h6">{hint.hintTitle}</Typography>
+                  <Typography variant="body1">{hint.hint}</Typography>
                 </AccordionDetails>
               </Accordion>
             );

--- a/src/components/features/hint/Hint.tsx
+++ b/src/components/features/hint/Hint.tsx
@@ -24,7 +24,7 @@ interface HintData {
 }
 
 export const Hint = () => {
-  const { partType } = useContext(HintContext);
+  const { currentPartType } = useContext(HintContext);
   const { hintTypeC } = useContext(HintContext);
 
   //TODO: GCPのFirestoreからヒントデータを取ってくる
@@ -102,7 +102,7 @@ export const Hint = () => {
   //partTypeの変更を検知し、それに合ったヒントをカレントなヒントデータとする
   useEffect(() => {
     hintData.map((hint) => {
-      if (hint.partType == partType) {
+      if (hint.partType == currentPartType) {
         setCurrentHintData(hint);
       }
     });
@@ -115,7 +115,7 @@ export const Hint = () => {
     width: "100%",
   };
 
-  console.log(partType);
+  console.log(currentPartType);
   console.log(hintTypeC);
 
   return (

--- a/src/components/features/hint/Hint.tsx
+++ b/src/components/features/hint/Hint.tsx
@@ -27,6 +27,7 @@ export const Hint = () => {
   const { partType } = useContext(HintContext);
   const { hintTypeC } = useContext(HintContext);
 
+  //TODO: GCPのFirestoreからヒントデータを取ってくる
   const hintData: HintData[] = [
     {
       partType: "DAMY",

--- a/src/components/features/hint/Hint.tsx
+++ b/src/components/features/hint/Hint.tsx
@@ -12,23 +12,78 @@ import {
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
-type Props = {
-  stepNo: number;
-  stepName: string;
-  hintList: HintList[];
-};
-
 interface HintList {
+  hintTitle: string;
   hint: string;
-  explanation: string;
 }
 
-export const Hint = (props: Props) => {
+interface HintData {
+  partType: string;
+  partTitle: string;
+  hintList: HintList[];
+}
+
+export const Hint = () => {
   //ヒントのリスト（MainPageから渡された）
-  const hintList: HintList[] = props.hintList;
-  const stepName: string = props.stepName;
   const { hintListIdx } = useContext(HintContext);
   const { hintTypeC } = useContext(HintContext);
+
+  let hintData: HintData[] = [
+    {
+      partType: "PROC",
+      partTitle: "計算・代入",
+      hintList: [
+        {
+          hintTitle: "何を書くパートなのかわからない",
+          hint: "ここには、計算・代入の処理を記述します",
+        },
+        {
+          hintTitle: "計算・代入の処理の書き方がわからない",
+          hint: "文法の説明",
+        },
+        {
+          hintTitle: "何を計算、代入したらいいかわからない",
+          hint: "説明",
+        },
+      ],
+    },
+    {
+      partType: "FOR",
+      partTitle: "繰り返し（for）",
+      hintList: [
+        {
+          hintTitle: "何を書くパートなのかわからない",
+          hint: "ここには、繰り返し（for）を記述します",
+        },
+        {
+          hintTitle: "繰り返し（for）の書き方がわからない",
+          hint: "文法の説明",
+        },
+        {
+          hintTitle: "どのような繰り返しの設定にしたらいいかわからない",
+          hint: "説明",
+        },
+      ],
+    },
+    {
+      partType: "FUN",
+      partTitle: "関数定義",
+      hintList: [
+        {
+          hintTitle: "何を書くパートなのかわからない",
+          hint: "ここには、関数定義を記述します",
+        },
+        {
+          hintTitle: "関数定義の書き方がわからない",
+          hint: "文法の説明",
+        },
+        {
+          hintTitle: "どのような関数を定義したらいいかわからない",
+          hint: "説明",
+        },
+      ],
+    },
+  ];
 
   const grammerCodeStyle = {
     backgroundColor: "#363636",
@@ -41,9 +96,7 @@ export const Hint = (props: Props) => {
 
   return (
     <Container maxWidth="md">
-      <Typography variant="h4">
-        STEP{hintListIdx}: {stepName}
-      </Typography>
+      <Typography variant="h4">STEP{hintListIdx}: ステップ名</Typography>
       <Container maxWidth="md" sx={{ marginBottom: "30px" }}>
         <div>
           {hintList.map((hint, index) => {

--- a/src/components/features/hint/Hint.tsx
+++ b/src/components/features/hint/Hint.tsx
@@ -133,9 +133,6 @@ export const Hint = () => {
     width: "100%",
   };
 
-  console.log(currentPartType);
-  console.log(hintTypeC);
-
   return (
     <Container maxWidth="md">
       <Typography variant="h4">STEP1: ステップ名</Typography>

--- a/src/components/features/hint/Hint.tsx
+++ b/src/components/features/hint/Hint.tsx
@@ -27,7 +27,7 @@ export const Hint = () => {
   const { partType } = useContext(HintContext);
   const { hintTypeC } = useContext(HintContext);
 
-  let hintData: HintData[] = [
+  const hintData: HintData[] = [
     {
       partType: "DAMY",
       partTitle: "ヒント非表示",
@@ -52,7 +52,7 @@ export const Hint = () => {
         },
         {
           hintTitle: "何を計算、代入したらいいかわからない",
-          hint: "説明",
+          hint: "",
         },
       ],
     },
@@ -70,7 +70,7 @@ export const Hint = () => {
         },
         {
           hintTitle: "どのような繰り返しの設定にしたらいいかわからない",
-          hint: "説明",
+          hint: "",
         },
       ],
     },
@@ -88,14 +88,14 @@ export const Hint = () => {
         },
         {
           hintTitle: "どのような関数を定義したらいいかわからない",
-          hint: "説明",
+          hint: "",
         },
       ],
     },
   ];
 
   //TypeCのヒントを展開するためのIdx
-  const [hintTypeCIdx] = useState<number>(0);
+  const [hintTypeCIdx, setHintTypeCIdx] = useState<number>(0);
   const [currentHintData, setCurrentHintData] = useState<HintData>(hintData[0]);
 
   //partTypeの変更を検知し、それに合ったヒントをカレントなヒントデータとする
@@ -123,6 +123,10 @@ export const Hint = () => {
       <Container maxWidth="md" sx={{ marginBottom: "30px" }}>
         <div>
           {currentHintData.hintList.map((hint, index) => {
+            if (hint.hint == "") {
+              hint.hint = hintTypeC;
+              setHintTypeCIdx(hintTypeCIdx + 1);
+            }
             return (
               <Accordion key={hint.hint}>
                 <AccordionSummary
@@ -132,7 +136,7 @@ export const Hint = () => {
                   sx={{ backgroundColor: "#e3f4ff" }}
                 >
                   <Typography variant="h5">
-                    つまずき{index + 1}：{hint.hint}
+                    つまずき{index + 1}：{hint.hintTitle}
                   </Typography>
                 </AccordionSummary>
                 <AccordionDetails>

--- a/src/components/features/hint/Hint.tsx
+++ b/src/components/features/hint/Hint.tsx
@@ -93,6 +93,24 @@ export const Hint = () => {
         },
       ],
     },
+    {
+      partType: "WHL",
+      partTitle: "繰り返し（while）",
+      hintList: [
+        {
+          hintTitle: "何を書くパートなのかわからない",
+          hint: "ここには、繰り返し（while）を記述します",
+        },
+        {
+          hintTitle: "繰り返し（while）の書き方がわからない",
+          hint: "文法の説明",
+        },
+        {
+          hintTitle: "どのような繰り返しの設定にしたら良いかわからない",
+          hint: "",
+        },
+      ],
+    },
   ];
 
   //TypeCのヒントを展開するためのIdx

--- a/src/components/features/hint/HintProvider.tsx
+++ b/src/components/features/hint/HintProvider.tsx
@@ -1,12 +1,19 @@
-import { createContext, useState } from "react";
+import { Dispatch, SetStateAction, createContext, useState } from "react";
 
-export const HintContext = createContext({});
+export const HintContext = createContext(
+  {} as {
+    hintListIdx: number;
+    setHintListIdx: Dispatch<SetStateAction<number>>;
+  }
+);
 
-export const HintProvider = (props: { children: any }) => {
-  const [hintListIdx, setHintListIdx] = useState(0);
+export const HintProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [hintListIdx, setHintListIdx] = useState<number>(1);
   return (
     <HintContext.Provider value={{ hintListIdx, setHintListIdx }}>
-      {props.children}
+      {children}
     </HintContext.Provider>
   );
 };

--- a/src/components/features/hint/HintProvider.tsx
+++ b/src/components/features/hint/HintProvider.tsx
@@ -4,6 +4,8 @@ export const HintContext = createContext(
   {} as {
     hintListIdx: number;
     setHintListIdx: Dispatch<SetStateAction<number>>;
+    hintTypeC: string;
+    setHintTypeC: Dispatch<SetStateAction<string>>;
   }
 );
 
@@ -12,8 +14,11 @@ export const HintProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [hintListIdx, setHintListIdx] = useState<number>(1);
+  const [hintTypeC, setHintTypeC] = useState<string>("テストヒントC");
   return (
-    <HintContext.Provider value={{ hintListIdx, setHintListIdx }}>
+    <HintContext.Provider
+      value={{ hintListIdx, setHintListIdx, hintTypeC, setHintTypeC }}
+    >
       {children}
     </HintContext.Provider>
   );

--- a/src/components/features/hint/HintProvider.tsx
+++ b/src/components/features/hint/HintProvider.tsx
@@ -2,8 +2,8 @@ import { Dispatch, SetStateAction, createContext, useState } from "react";
 
 export const HintContext = createContext(
   {} as {
-    hintListIdx: number;
-    setHintListIdx: Dispatch<SetStateAction<number>>;
+    partType: string;
+    setPartType: Dispatch<SetStateAction<string>>;
     hintTypeC: string;
     setHintTypeC: Dispatch<SetStateAction<string>>;
   }
@@ -13,11 +13,11 @@ export const HintProvider: React.FC<{ children: React.ReactNode }> = ({
   //eslint-disable-next-line
   children,
 }) => {
-  const [hintListIdx, setHintListIdx] = useState<number>(1);
+  const [partType, setPartType] = useState<string>("PROC");
   const [hintTypeC, setHintTypeC] = useState<string>("テストヒントC");
   return (
     <HintContext.Provider
-      value={{ hintListIdx, setHintListIdx, hintTypeC, setHintTypeC }}
+      value={{ partType, setPartType, hintTypeC, setHintTypeC }}
     >
       {children}
     </HintContext.Provider>

--- a/src/components/features/hint/HintProvider.tsx
+++ b/src/components/features/hint/HintProvider.tsx
@@ -13,7 +13,7 @@ export const HintProvider: React.FC<{ children: React.ReactNode }> = ({
   //eslint-disable-next-line
   children,
 }) => {
-  const [partType, setPartType] = useState<string>("PROC");
+  const [partType, setPartType] = useState<string>("FOR");
   const [hintTypeC, setHintTypeC] = useState<string>("テストヒントC");
   return (
     <HintContext.Provider

--- a/src/components/features/hint/HintProvider.tsx
+++ b/src/components/features/hint/HintProvider.tsx
@@ -1,0 +1,12 @@
+import { createContext, useState } from "react";
+
+export const HintContext = createContext({});
+
+export const HintProvider = (props: { children: any }) => {
+  const [hintListIdx, setHintListIdx] = useState(0);
+  return (
+    <HintContext.Provider value={{ hintListIdx, setHintListIdx }}>
+      {props.children}
+    </HintContext.Provider>
+  );
+};

--- a/src/components/features/hint/HintProvider.tsx
+++ b/src/components/features/hint/HintProvider.tsx
@@ -8,6 +8,7 @@ export const HintContext = createContext(
 );
 
 export const HintProvider: React.FC<{ children: React.ReactNode }> = ({
+  //eslint-disable-next-line
   children,
 }) => {
   const [hintListIdx, setHintListIdx] = useState<number>(1);

--- a/src/components/features/hint/HintProvider.tsx
+++ b/src/components/features/hint/HintProvider.tsx
@@ -2,8 +2,8 @@ import { Dispatch, SetStateAction, createContext, useState } from "react";
 
 export const HintContext = createContext(
   {} as {
-    partType: string;
-    setPartType: Dispatch<SetStateAction<string>>;
+    currentPartType: string;
+    setCurrentPartType: Dispatch<SetStateAction<string>>;
     hintTypeC: string;
     setHintTypeC: Dispatch<SetStateAction<string>>;
   }
@@ -13,11 +13,11 @@ export const HintProvider: React.FC<{ children: React.ReactNode }> = ({
   //eslint-disable-next-line
   children,
 }) => {
-  const [partType, setPartType] = useState<string>("FOR");
+  const [currentPartType, setCurrentPartType] = useState<string>("FOR");
   const [hintTypeC, setHintTypeC] = useState<string>("テストヒントC");
   return (
     <HintContext.Provider
-      value={{ partType, setPartType, hintTypeC, setHintTypeC }}
+      value={{ currentPartType, setCurrentPartType, hintTypeC, setHintTypeC }}
     >
       {children}
     </HintContext.Provider>


### PR DESCRIPTION
# 変更
* 表示するヒントのパートタイプと、ヒントタイプCの説明を格納できるグローバルステート（Context）を用意した。
* ヒントデータの記述・処理の場所をHintコンポーネントに移動した
* 入力欄によって、表示するヒント（カレントなヒント）を切り替えられるようにした。
* ヒントデータにヒントデータがなければ、問題にあるタイプCのヒントを格納するようにした。
* フォームの構成時にexplanationフィールドを渡せるようにした。
* 不要なconsole.logを削除した。

# テスト
ブラウザで、入力欄をクリックした時にそのパートのヒントに正しく切り替わることを確認した。

# issue
closed #12 