### PR TITLE
各タイプのヒントコンポーネントを作成した。

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { TopPage } from "./components/pages/TopPage";
 import { FormPage } from "./components/pages/FormPage";
 import { TitleBar } from "./components/common/TitleBar";
 import { HintProvider } from "./components/features/hint/HintProvider";
+import { HintCompProvider } from "./components/features/hint/HintCompProvider";
 
 function App() {
   return (
@@ -20,8 +21,8 @@ function App() {
           <TitleBar barType="form" formName="サンプルフォーム" />
           <FormPage />
         </Route>
-        <Route path="/testTitle">
-          <TitleBar barType="nomal" formName="" />
+        <Route path="/hintprovider">
+          <HintCompProvider />
         </Route>
       </BrowserRouter>
     </HintProvider>

--- a/src/components/features/hint/Hint.tsx
+++ b/src/components/features/hint/Hint.tsx
@@ -12,7 +12,10 @@ import {
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
+import { HintCompProvider } from "./HintCompProvider";
+
 interface HintList {
+  hintType: string;
   hintTitle: string;
   hint: string;
 }
@@ -34,6 +37,7 @@ export const Hint = () => {
       partTitle: "ヒント非表示",
       hintList: [
         {
+          hintType: "A",
           hintTitle: "つまずきに応じたヒントを出します",
           hint: "ヒントの説明",
         },
@@ -44,14 +48,17 @@ export const Hint = () => {
       partTitle: "計算・代入",
       hintList: [
         {
+          hintType: "A",
           hintTitle: "何を書くパートなのかわからない",
           hint: "ここには、計算・代入の処理を記述します",
         },
         {
+          hintType: "B",
           hintTitle: "計算・代入の処理の書き方がわからない",
           hint: "文法の説明",
         },
         {
+          hintType: "C",
           hintTitle: "何を計算、代入したらいいかわからない",
           hint: "",
         },
@@ -62,14 +69,17 @@ export const Hint = () => {
       partTitle: "繰り返し（for）",
       hintList: [
         {
+          hintType: "A",
           hintTitle: "何を書くパートなのかわからない",
           hint: "ここには、繰り返し（for）を記述します",
         },
         {
+          hintType: "B",
           hintTitle: "繰り返し（for）の書き方がわからない",
           hint: "文法の説明",
         },
         {
+          hintType: "C",
           hintTitle: "どのような繰り返しの設定にしたらいいかわからない",
           hint: "",
         },
@@ -80,14 +90,17 @@ export const Hint = () => {
       partTitle: "関数定義",
       hintList: [
         {
+          hintType: "A",
           hintTitle: "何を書くパートなのかわからない",
           hint: "ここには、関数定義を記述します",
         },
         {
+          hintType: "B",
           hintTitle: "関数定義の書き方がわからない",
           hint: "文法の説明",
         },
         {
+          hintType: "C",
           hintTitle: "どのような関数を定義したらいいかわからない",
           hint: "",
         },
@@ -98,14 +111,17 @@ export const Hint = () => {
       partTitle: "繰り返し（while）",
       hintList: [
         {
+          hintType: "A",
           hintTitle: "何を書くパートなのかわからない",
           hint: "ここには、繰り返し（while）を記述します",
         },
         {
+          hintType: "B",
           hintTitle: "繰り返し（while）の書き方がわからない",
           hint: "文法の説明",
         },
         {
+          hintType: "C",
           hintTitle: "どのような繰り返しの設定にしたら良いかわからない",
           hint: "",
         },
@@ -156,8 +172,7 @@ export const Hint = () => {
                   </Typography>
                 </AccordionSummary>
                 <AccordionDetails>
-                  <Typography variant="h6">{hint.hintTitle}</Typography>
-                  <Typography variant="body1">{hint.hint}</Typography>
+                  <HintCompProvider hintType={hint.hintType} />
                 </AccordionDetails>
               </Accordion>
             );

--- a/src/components/features/hint/HintCompProvider.tsx
+++ b/src/components/features/hint/HintCompProvider.tsx
@@ -1,0 +1,3 @@
+export const HintCompProvider = () => {
+  return <h1>ヒントのコンポーネントプロバイダー</h1>;
+};

--- a/src/components/features/hint/HintCompProvider.tsx
+++ b/src/components/features/hint/HintCompProvider.tsx
@@ -1,3 +1,20 @@
+import { useState } from "react";
+import { TypeA } from "./hintComponents/TypeA";
+import { TypeB } from "./hintComponents/TypeB";
+import { TypeC } from "./hintComponents/TypeC";
+
 export const HintCompProvider = () => {
-  return <h1>ヒントのコンポーネントプロバイダー</h1>;
+  const [formType] = useState<string>("d");
+  if (formType == "a") {
+    return <TypeA />;
+  } else if (formType == "b") {
+    return <TypeB />;
+  } else if (formType == "c") {
+    return <TypeC />;
+  } else {
+    alert(
+      "データ不正エラー：無効なヒントタイプがヒントデータに使用されています。管理者に連絡してください。"
+    );
+    return <h1>エラー：管理者への連絡が必要です。</h1>;
+  }
 };

--- a/src/components/features/hint/HintCompProvider.tsx
+++ b/src/components/features/hint/HintCompProvider.tsx
@@ -1,15 +1,18 @@
-import { useState } from "react";
 import { TypeA } from "./hintComponents/TypeA";
 import { TypeB } from "./hintComponents/TypeB";
 import { TypeC } from "./hintComponents/TypeC";
 
-export const HintCompProvider = () => {
-  const [formType] = useState<string>("C");
-  if (formType == "A") {
+type Props = {
+  hintType: string;
+};
+
+export const HintCompProvider = (props: Props) => {
+  const hintType = props.hintType;
+  if (hintType == "A") {
     return <TypeA />;
-  } else if (formType == "B") {
+  } else if (hintType == "B") {
     return <TypeB />;
-  } else if (formType == "C") {
+  } else if (hintType == "C") {
     return <TypeC />;
   } else {
     alert(

--- a/src/components/features/hint/HintCompProvider.tsx
+++ b/src/components/features/hint/HintCompProvider.tsx
@@ -4,12 +4,12 @@ import { TypeB } from "./hintComponents/TypeB";
 import { TypeC } from "./hintComponents/TypeC";
 
 export const HintCompProvider = () => {
-  const [formType] = useState<string>("d");
-  if (formType == "a") {
+  const [formType] = useState<string>("C");
+  if (formType == "A") {
     return <TypeA />;
-  } else if (formType == "b") {
+  } else if (formType == "B") {
     return <TypeB />;
-  } else if (formType == "c") {
+  } else if (formType == "C") {
     return <TypeC />;
   } else {
     alert(

--- a/src/components/features/hint/hintComponents/TypeA.tsx
+++ b/src/components/features/hint/hintComponents/TypeA.tsx
@@ -1,0 +1,3 @@
+export const TypeA = () => {
+  return <h1>タイプAのヒントコンポーネントです。</h1>;
+};

--- a/src/components/features/hint/hintComponents/TypeA.tsx
+++ b/src/components/features/hint/hintComponents/TypeA.tsx
@@ -1,3 +1,12 @@
+import { Typography } from "@mui/material";
+
 export const TypeA = () => {
-  return <h1>タイプAのヒントコンポーネントです。</h1>;
+  return (
+    <>
+      <Typography variant="h6">
+        ここには、繰り返し（for）を記述します
+      </Typography>
+      <Typography variant="body1">目的の説明</Typography>
+    </>
+  );
 };

--- a/src/components/features/hint/hintComponents/TypeB.tsx
+++ b/src/components/features/hint/hintComponents/TypeB.tsx
@@ -1,0 +1,3 @@
+export const TypeB = () => {
+  return <h1>タイプBのヒントコンポーネントです。</h1>;
+};

--- a/src/components/features/hint/hintComponents/TypeB.tsx
+++ b/src/components/features/hint/hintComponents/TypeB.tsx
@@ -1,3 +1,30 @@
+import { Typography } from "@mui/material";
+
 export const TypeB = () => {
-  return <h1>タイプBのヒントコンポーネントです。</h1>;
+  const grammerCodeStyle = {
+    backgroundColor: "#363636",
+    fontSize: "14pt",
+    color: "#fff",
+    width: "100%",
+  };
+
+  const sampleCode =
+    'for ("カウンタ変数の初期化"; "継続条件"; "カウンタの増減") {\n   //継続条件を満たす間繰り返す処理\n}';
+
+  return (
+    <>
+      <Typography variant="h6">for文の書き方</Typography>
+      <textarea style={grammerCodeStyle} cols={40} rows={4}>
+        {sampleCode}
+      </textarea>
+      <br />
+      <Typography variant="body1">
+        カウンタ変数の初期化：何回目のループかをカウントする変数を初期化します。通常は0で初期化します。
+        <br />
+        継続条件：ループの中身に書く処理を、何の条件を満たす間行うかを条件式で設定します。
+        <br />
+        カウンタの増減：ループの中身の処理を一回実行した時に、カウンタ変数をどのように増減するかを設定します。通常は１つずつ増やすカウントアップを行います。
+      </Typography>
+    </>
+  );
 };

--- a/src/components/features/hint/hintComponents/TypeC.tsx
+++ b/src/components/features/hint/hintComponents/TypeC.tsx
@@ -1,0 +1,3 @@
+export const TypeC = () => {
+  return <h1>タイプCのヒントコンポーネントです。</h1>;
+};

--- a/src/components/features/hint/hintComponents/TypeC.tsx
+++ b/src/components/features/hint/hintComponents/TypeC.tsx
@@ -1,3 +1,10 @@
+import { Typography } from "@mui/material";
+
 export const TypeC = () => {
-  return <h1>タイプCのヒントコンポーネントです。</h1>;
+  return (
+    <>
+      <Typography variant="h6">解説</Typography>
+      <Typography variant="body1">目的の説明</Typography>
+    </>
+  );
 };


### PR DESCRIPTION
# 変更
* ヒントデータに基づき、適切なタイプのヒントコンポーネントを返すHintCompProviderコンポーネントを作成した。
* タイプA〜Cのコンポーネントを作成した。
* タイプA〜Cのヒント内容をとりあえず用意して作成した。
* ヒントデータに、ヒントのタイプを示すhintTypeパラメータを追加した。

# 今後実装
* ヒントの説明を配列にして、タイプごとに適切に展開できるようにする。（データ構造を決める）
* ヒントの画面をよりわかりやすくする。

# テスト
/formにアクセスした時に、各タイプの画面が正しく表示されていることを確認した。

# issue
closed #21 