### PR TITLE
タイプBのヒントを画像で表示できる様にした。

### DIFF
--- a/src/components/features/hint/Hint.tsx
+++ b/src/components/features/hint/Hint.tsx
@@ -109,7 +109,7 @@ export const Hint = () => {
 
   return (
     <Container maxWidth="md">
-      <Typography variant="h4">STEP1: ステップ名</Typography>
+      <Typography variant="h4">{currentHintData.partTitle}</Typography>
       <Container maxWidth="md" sx={{ marginBottom: "30px" }}>
         <div>
           {currentHintData.hintList.map((hint, index) => {

--- a/src/components/features/hint/Hint.tsx
+++ b/src/components/features/hint/Hint.tsx
@@ -130,7 +130,10 @@ export const Hint = () => {
                   </Typography>
                 </AccordionSummary>
                 <AccordionDetails>
-                  <HintCompProvider hintType={hint.hintType} />
+                  <HintCompProvider
+                    hintData={currentHintData}
+                    hintType={hint.hintType}
+                  />
                 </AccordionDetails>
               </Accordion>
             );

--- a/src/components/features/hint/Hint.tsx
+++ b/src/components/features/hint/Hint.tsx
@@ -17,17 +17,7 @@ import { HintCompProvider } from "./HintCompProvider";
 import { storage } from "../../../firebase";
 import { getDownloadURL, ref } from "firebase/storage";
 
-interface HintList {
-  hintType: string;
-  hintTitle: string;
-  hint: string;
-}
-
-interface HintData {
-  partType: string;
-  partTitle: string;
-  hintList: HintList[];
-}
+import { HintData } from "../../types/hintData";
 
 export const Hint = () => {
   const { currentPartType } = useContext(HintContext);

--- a/src/components/features/hint/Hint.tsx
+++ b/src/components/features/hint/Hint.tsx
@@ -120,10 +120,7 @@ export const Hint = () => {
                   </Typography>
                 </AccordionSummary>
                 <AccordionDetails>
-                  <HintCompProvider
-                    hintData={currentHintData}
-                    hintType={hint.hintType}
-                  />
+                  <HintCompProvider hint={hint} />
                 </AccordionDetails>
               </Accordion>
             );

--- a/src/components/features/hint/Hint.tsx
+++ b/src/components/features/hint/Hint.tsx
@@ -120,7 +120,10 @@ export const Hint = () => {
                   </Typography>
                 </AccordionSummary>
                 <AccordionDetails>
-                  <HintCompProvider hint={hint} />
+                  <HintCompProvider
+                    hint={hint}
+                    partType={currentHintData.partType}
+                  />
                 </AccordionDetails>
               </Accordion>
             );

--- a/src/components/features/hint/HintCompProvider.tsx
+++ b/src/components/features/hint/HintCompProvider.tsx
@@ -3,8 +3,21 @@ import { TypeB } from "./hintComponents/TypeB";
 import { TypeC } from "./hintComponents/TypeC";
 
 type Props = {
+  hintData: HintData;
   hintType: string;
 };
+
+interface HintData {
+  partType: string;
+  partTitle: string;
+  hintList: HintList[];
+}
+
+interface HintList {
+  hintType: string;
+  hintTitle: string;
+  hint: string;
+}
 
 export const HintCompProvider = (props: Props) => {
   const hintType = props.hintType;

--- a/src/components/features/hint/HintCompProvider.tsx
+++ b/src/components/features/hint/HintCompProvider.tsx
@@ -6,14 +6,17 @@ import { HintList } from "../../types/hintData";
 
 type Props = {
   hint: HintList;
+  partType: string;
 };
 
 export const HintCompProvider = (props: Props) => {
   const hint = props.hint;
+  const partType = props.partType;
+
   if (hint.hintType == "A") {
     return <TypeA hintText={hint.hint} />;
   } else if (hint.hintType == "B") {
-    return <TypeB imgUrl={hint.hint} />;
+    return <TypeB partType={partType} />;
   } else if (hint.hintType == "C") {
     return <TypeC explanation={hint.hint} />;
   } else {

--- a/src/components/features/hint/HintCompProvider.tsx
+++ b/src/components/features/hint/HintCompProvider.tsx
@@ -9,13 +9,13 @@ type Props = {
 };
 
 export const HintCompProvider = (props: Props) => {
-  const hintType = props.hint.hintType;
-  if (hintType == "A") {
-    return <TypeA />;
-  } else if (hintType == "B") {
-    return <TypeB />;
-  } else if (hintType == "C") {
-    return <TypeC />;
+  const hint = props.hint;
+  if (hint.hintType == "A") {
+    return <TypeA hintText={hint.hint} />;
+  } else if (hint.hintType == "B") {
+    return <TypeB imgUrl={hint.hint} />;
+  } else if (hint.hintType == "C") {
+    return <TypeC explanation={hint.hint} />;
   } else {
     alert(
       "データ不正エラー：無効なヒントタイプがヒントデータに使用されています。管理者に連絡してください。"

--- a/src/components/features/hint/HintCompProvider.tsx
+++ b/src/components/features/hint/HintCompProvider.tsx
@@ -2,15 +2,14 @@ import { TypeA } from "./hintComponents/TypeA";
 import { TypeB } from "./hintComponents/TypeB";
 import { TypeC } from "./hintComponents/TypeC";
 
-import { HintData } from "../../types/hintData";
+import { HintList } from "../../types/hintData";
 
 type Props = {
-  hintData: HintData;
-  hintType: string;
+  hint: HintList;
 };
 
 export const HintCompProvider = (props: Props) => {
-  const hintType = props.hintType;
+  const hintType = props.hint.hintType;
   if (hintType == "A") {
     return <TypeA />;
   } else if (hintType == "B") {

--- a/src/components/features/hint/HintCompProvider.tsx
+++ b/src/components/features/hint/HintCompProvider.tsx
@@ -2,22 +2,12 @@ import { TypeA } from "./hintComponents/TypeA";
 import { TypeB } from "./hintComponents/TypeB";
 import { TypeC } from "./hintComponents/TypeC";
 
+import { HintData } from "../../types/hintData";
+
 type Props = {
   hintData: HintData;
   hintType: string;
 };
-
-interface HintData {
-  partType: string;
-  partTitle: string;
-  hintList: HintList[];
-}
-
-interface HintList {
-  hintType: string;
-  hintTitle: string;
-  hint: string;
-}
 
 export const HintCompProvider = (props: Props) => {
   const hintType = props.hintType;

--- a/src/components/features/hint/hintComponents/TypeA.tsx
+++ b/src/components/features/hint/hintComponents/TypeA.tsx
@@ -1,11 +1,14 @@
 import { Typography } from "@mui/material";
 
-export const TypeA = () => {
+type Props = {
+  hintText: string;
+};
+
+export const TypeA = (props: Props) => {
+  const hintText = props.hintText;
   return (
     <>
-      <Typography variant="h6">
-        ここには、繰り返し（for）を記述します
-      </Typography>
+      <Typography variant="h6">{hintText}</Typography>
       <Typography variant="body1">目的の説明</Typography>
     </>
   );

--- a/src/components/features/hint/hintComponents/TypeB.tsx
+++ b/src/components/features/hint/hintComponents/TypeB.tsx
@@ -1,6 +1,12 @@
 import { Typography } from "@mui/material";
 
-export const TypeB = () => {
+type Props = {
+  imgUrl: string;
+};
+
+export const TypeB = (props: Props) => {
+  const imgUrl = props.imgUrl;
+
   const grammerCodeStyle = {
     backgroundColor: "#363636",
     fontSize: "14pt",

--- a/src/components/features/hint/hintComponents/TypeB.tsx
+++ b/src/components/features/hint/hintComponents/TypeB.tsx
@@ -1,36 +1,54 @@
 import { Typography } from "@mui/material";
+import { getDownloadURL, ref } from "firebase/storage";
+import { storage } from "../../../../firebase";
+import { useEffect, useState } from "react";
 
 type Props = {
-  imgUrl: string;
+  partType: string;
 };
 
 export const TypeB = (props: Props) => {
-  const imgUrl = props.imgUrl;
+  const partType = props.partType;
+  const [imgUrl, setImgUrl] = useState<string>("");
 
-  const grammerCodeStyle = {
-    backgroundColor: "#363636",
-    fontSize: "14pt",
-    color: "#fff",
-    width: "100%",
+  //partTypeの変更を検知し、それに合ったヒントをカレントなヒントデータとする
+  useEffect(() => {
+    getHintData("nothing");
+  }, []);
+
+  const getHintData = (fileName: string) => {
+    const refUrl = "hint/partB/" + fileName + ".png";
+    getFileUrl(refUrl);
   };
 
-  const sampleCode =
-    'for ("カウンタ変数の初期化"; "継続条件"; "カウンタの増減") {\n   //継続条件を満たす間繰り返す処理\n}';
+  const getFileUrl = (refUrl: string) => {
+    getDownloadURL(ref(storage, refUrl))
+      .then((url) => {
+        setImgUrl(url);
+      })
+      .catch((error) => {
+        // A full list of error codes is available at
+        // https://firebase.google.com/docs/storage/web/handle-errors
+        switch (error.code) {
+          case "storage/object-not-found":
+            alert("ファイルが見つかりません！");
+            break;
+          case "storage/unauthorized":
+            alert("このファイルへのアクセス権限がありません！");
+            break;
+          case "storage/canceled":
+            alert("ユーザーはアップロードをキャンセルしました。");
+            break;
+          case "storage/unknown":
+            alert("不明なエラーが発生しました！");
+            break;
+        }
+      });
+  };
 
   return (
     <>
-      <Typography variant="h6">for文の書き方</Typography>
-      <textarea style={grammerCodeStyle} cols={40} rows={4}>
-        {sampleCode}
-      </textarea>
-      <br />
-      <Typography variant="body1">
-        カウンタ変数の初期化：何回目のループかをカウントする変数を初期化します。通常は0で初期化します。
-        <br />
-        継続条件：ループの中身に書く処理を、何の条件を満たす間行うかを条件式で設定します。
-        <br />
-        カウンタの増減：ループの中身の処理を一回実行した時に、カウンタ変数をどのように増減するかを設定します。通常は１つずつ増やすカウントアップを行います。
-      </Typography>
+      <img src={imgUrl} style={{ width: "90%" }} alt="解説画像" />
     </>
   );
 };

--- a/src/components/features/hint/hintComponents/TypeB.tsx
+++ b/src/components/features/hint/hintComponents/TypeB.tsx
@@ -13,7 +13,7 @@ export const TypeB = (props: Props) => {
 
   //partTypeの変更を検知し、それに合ったヒントをカレントなヒントデータとする
   useEffect(() => {
-    getHintData("nothing");
+    getHintData(partType);
   }, []);
 
   const getHintData = (fileName: string) => {
@@ -32,15 +32,19 @@ export const TypeB = (props: Props) => {
         switch (error.code) {
           case "storage/object-not-found":
             alert("ファイルが見つかりません！");
+            getHintData("nothing");
             break;
           case "storage/unauthorized":
             alert("このファイルへのアクセス権限がありません！");
+            getHintData("nothing");
             break;
           case "storage/canceled":
             alert("ユーザーはアップロードをキャンセルしました。");
+            getHintData("nothing");
             break;
           case "storage/unknown":
             alert("不明なエラーが発生しました！");
+            getHintData("nothing");
             break;
         }
       });

--- a/src/components/features/hint/hintComponents/TypeC.tsx
+++ b/src/components/features/hint/hintComponents/TypeC.tsx
@@ -1,10 +1,15 @@
 import { Typography } from "@mui/material";
 
-export const TypeC = () => {
+type Props = {
+  explanation: string;
+};
+
+export const TypeC = (props: Props) => {
+  const explanation = props.explanation;
   return (
     <>
       <Typography variant="h6">解説</Typography>
-      <Typography variant="body1">目的の説明</Typography>
+      <Typography variant="body1">{explanation}</Typography>
     </>
   );
 };

--- a/src/components/types/hintData.ts
+++ b/src/components/types/hintData.ts
@@ -4,7 +4,7 @@ export type HintData = {
   hintList: HintList[];
 };
 
-type HintList = {
+export type HintList = {
   hintType: string;
   hintTitle: string;
   hint: string;

--- a/src/components/types/hintData.ts
+++ b/src/components/types/hintData.ts
@@ -1,0 +1,11 @@
+export type HintData = {
+  partType: string;
+  partTitle: string;
+  hintList: HintList[];
+};
+
+type HintList = {
+  hintType: string;
+  hintTitle: string;
+  hint: string;
+};


### PR DESCRIPTION
# 変更
* フォームの左上の表示内容を変更した（Hint.tsx）
* HintCompProviderに、各タイプのヒントと、パートタイプを渡す様にした。（Hint.tsx, HintCompProvider.tsx）
* フォームデータからヒントを展開できる様にした。
* ヒントタイプBの画像をCloud Storageから取得して表示できる様にした。（TypeB.tsx）
* 該当するヒント画像がないときは、ダミーの画像（ヒントデータ無し）を出す様にした。（TypeB.tsx）

# テスト
フォームである入力欄をフォーカスした時に、Cloud Storageに保存してあるダミーの画像が表示されることを確認した。

# 未対応
実際のヒント画像をCloud Storageに配置

# issue
closed #44 