### PR TITLE
選択されたフォームをダウンロードできる様にした。

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { TitleBar } from "./components/common/TitleBar";
 import { HintProvider } from "./components/features/hint/HintProvider";
 import { InputArrayProvider } from "./components/features/form/InputArrayProvider";
 import { StorageTestPage } from "./components/pages/StorageTestPage";
+import { LearningPage } from "./components/pages/LearningPage";
 
 function App() {
   return (
@@ -15,9 +16,9 @@ function App() {
             <TitleBar />
             <TopPage />
           </Route>
-          <Route path="/learn">
+          <Route path="/learning">
             <TitleBar />
-            <p>学習ページがきます。</p>
+            <LearningPage />
           </Route>
           <Route path="/form">
             <FormPage />

--- a/src/components/features/form/Form.tsx
+++ b/src/components/features/form/Form.tsx
@@ -38,10 +38,18 @@ export const Form = () => {
 
   useEffect(() => {
     initInputArray(sampleInputData);
-    getFormData("sampleForm");
+
+    //リクエストパラメータのフォーム名を取得し、フォームを取得する
+    const url = new URL(window.location.href);
+    const formName = url.searchParams.get("form");
+    if (formName == null) {
+      alert("フォームの種類が選択されていません。フォーム選択画面に戻ります。");
+      window.location.href = "/learning";
+    }
+    getFormData(formName);
   }, []);
 
-  const getFormData = (formName: string) => {
+  const getFormData = (formName: string | null) => {
     const refUrl = "form/" + formName + ".json";
     getFileUrl(refUrl);
   };
@@ -56,16 +64,24 @@ export const Form = () => {
         // https://firebase.google.com/docs/storage/web/handle-errors
         switch (error.code) {
           case "storage/object-not-found":
-            alert("ファイルが見つかりません！");
+            alert("ファイルが見つかりません！フォーム選択画面に戻ります。");
+            window.location.href = "/learning";
             break;
           case "storage/unauthorized":
-            alert("このファイルへのアクセス権限がありません！");
+            alert(
+              "このファイルへのアクセス権限がありません！フォーム選択画面に戻ります。"
+            );
+            window.location.href = "/learning";
             break;
           case "storage/canceled":
-            alert("ユーザーはアップロードをキャンセルしました。");
+            alert(
+              "ユーザーはアップロードをキャンセルしました。フォーム選択画面に戻ります。"
+            );
+            window.location.href = "/learning";
             break;
           case "storage/unknown":
-            alert("不明なエラーが発生しました！");
+            alert("不明なエラーが発生しました！フォーム選択画面に戻ります。");
+            window.location.href = "/learning";
             break;
         }
       });

--- a/src/components/features/leaning/Learning.tsx
+++ b/src/components/features/leaning/Learning.tsx
@@ -6,7 +6,7 @@ export const Learning = () => {
       <Button
         size="large"
         onClick={() => {
-          window.open("/form?id=1", "_blank");
+          window.open("/form?form=sampleForm", "_blank");
         }}
       >
         実験用フォーム1
@@ -14,7 +14,7 @@ export const Learning = () => {
       <Button
         size="large"
         onClick={() => {
-          window.open("/form?id=1", "_blank");
+          window.open("/form", "_blank");
         }}
       >
         実験用フォーム2

--- a/src/components/features/leaning/Learning.tsx
+++ b/src/components/features/leaning/Learning.tsx
@@ -1,3 +1,24 @@
+import { Box, Button } from "@mui/material";
+
 export const Learning = () => {
-  return <h1>学習ページ（フォーム選択）です。</h1>;
+  return (
+    <Box sx={{ height: "1000px", paddingTop: "100px" }}>
+      <Button
+        size="large"
+        onClick={() => {
+          window.open("/form?id=1", "_blank");
+        }}
+      >
+        実験用フォーム1
+      </Button>
+      <Button
+        size="large"
+        onClick={() => {
+          window.open("/form?id=1", "_blank");
+        }}
+      >
+        実験用フォーム2
+      </Button>
+    </Box>
+  );
 };

--- a/src/components/features/leaning/Learning.tsx
+++ b/src/components/features/leaning/Learning.tsx
@@ -1,0 +1,3 @@
+export const Learning = () => {
+  return <h1>学習ページ（フォーム選択）です。</h1>;
+};

--- a/src/components/pages/LearningPage.tsx
+++ b/src/components/pages/LearningPage.tsx
@@ -1,0 +1,5 @@
+import { Learning } from "../features/leaning/Learning";
+
+export const LearningPage = () => {
+  return <Learning />;
+};

--- a/src/components/types/formList.ts
+++ b/src/components/types/formList.ts
@@ -1,0 +1,5 @@
+export type FormList = {
+  formTitle: string;
+  formFileName: string;
+  formGroup: string;
+};


### PR DESCRIPTION
# 変更
* フォーム一覧（formList）の型を定義した。
* 学習ページ（フォーム選択画面）を用意して、ルーターに追加した。
* 選択したフォームの名前をパラメータで渡せるようにした。
* 渡された名前のフォームデータをダウンロードして表示できる様にした。
* フォームの画面は別のタブで開く様にした。
* 渡された名前のフォームのデータがない場合や、フォームの名前が渡されなかったときはアラートを出して、その後、学習ページに遷移する様にした。

# テスト
/learningにアクセスして、いずれかのフォームのボタンを押したら、新しいタブでフォームが開いて正しいデータが表示された。

# issue
#42 