### PR TITLE
fbData記録時に、フォームのidも記録できる様にした。

### DIFF
--- a/src/components/features/form/Form.tsx
+++ b/src/components/features/form/Form.tsx
@@ -143,6 +143,7 @@ export const Form = () => {
             <>
               <FormProvider
                 key={data.id}
+                id={data.id}
                 partType={data.partType}
                 explanation={data.explanation}
                 childrenPart={data.childrenPart}

--- a/src/components/features/form/FormProvider.tsx
+++ b/src/components/features/form/FormProvider.tsx
@@ -22,6 +22,7 @@ import { StructIn } from "./formComponents/StructIn";
 import { StrPro } from "./formComponents/StrPro";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   childrenPart: string | FormData[];
@@ -34,6 +35,7 @@ export const FormProvider = (props: Props) => {
   if (formData.partType == "MAIN") {
     return (
       <Main
+        id={formData.id}
         partType={formData.partType}
         childrenPart={formData.childrenPart}
         inputIdx={formData.inputIdx}
@@ -42,6 +44,7 @@ export const FormProvider = (props: Props) => {
   } else if (formData.partType == "PROC") {
     return (
       <Process
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         inputIdx={formData.inputIdx}
@@ -50,6 +53,7 @@ export const FormProvider = (props: Props) => {
   } else if (formData.partType == "FOR") {
     return (
       <For
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         childrenPart={formData.childrenPart}
@@ -59,6 +63,7 @@ export const FormProvider = (props: Props) => {
   } else if (formData.partType == "WHL") {
     return (
       <While
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         childrenPart={formData.childrenPart}
@@ -68,6 +73,7 @@ export const FormProvider = (props: Props) => {
   } else if (formData.partType == "FUN") {
     return (
       <Function
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         childrenPart={formData.childrenPart}
@@ -77,6 +83,7 @@ export const FormProvider = (props: Props) => {
   } else if (formData.partType == "IF") {
     return (
       <If
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         childrenPart={formData.childrenPart}
@@ -86,6 +93,7 @@ export const FormProvider = (props: Props) => {
   } else if (formData.partType == "ELIF") {
     return (
       <Elseif
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         childrenPart={formData.childrenPart}
@@ -95,6 +103,7 @@ export const FormProvider = (props: Props) => {
   } else if (formData.partType == "ELS") {
     return (
       <Else
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         childrenPart={formData.childrenPart}
@@ -106,6 +115,7 @@ export const FormProvider = (props: Props) => {
   } else if (formData.partType == "STRC") {
     return (
       <Struct
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         inputIdx={formData.inputIdx}
@@ -114,6 +124,7 @@ export const FormProvider = (props: Props) => {
   } else if (formData.partType == "INC") {
     return (
       <Include
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         inputIdx={formData.inputIdx}
@@ -122,6 +133,7 @@ export const FormProvider = (props: Props) => {
   } else if (formData.partType == "DEF") {
     return (
       <Define
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         inputIdx={formData.inputIdx}
@@ -130,6 +142,7 @@ export const FormProvider = (props: Props) => {
   } else if (formData.partType == "DAT") {
     return (
       <Data
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         inputIdx={formData.inputIdx}
@@ -138,6 +151,7 @@ export const FormProvider = (props: Props) => {
   } else if (formData.partType == "STRDC") {
     return (
       <StrDec
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         inputIdx={formData.inputIdx}
@@ -146,6 +160,7 @@ export const FormProvider = (props: Props) => {
   } else if (formData.partType == "INP") {
     return (
       <Input
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         inputIdx={formData.inputIdx}
@@ -154,6 +169,7 @@ export const FormProvider = (props: Props) => {
   } else if (formData.partType == "OUT") {
     return (
       <Output
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         inputIdx={formData.inputIdx}
@@ -162,6 +178,7 @@ export const FormProvider = (props: Props) => {
   } else if (formData.partType == "STRIN") {
     return (
       <StrIn
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         inputIdx={formData.inputIdx}
@@ -170,6 +187,7 @@ export const FormProvider = (props: Props) => {
   } else if (formData.partType == "STRCIN") {
     return (
       <StructIn
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         inputIdx={formData.inputIdx}
@@ -178,6 +196,7 @@ export const FormProvider = (props: Props) => {
   } else if (formData.partType == "STRCOU") {
     return (
       <StructOut
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         inputIdx={formData.inputIdx}
@@ -186,6 +205,7 @@ export const FormProvider = (props: Props) => {
   } else if (formData.partType == "STRP") {
     return (
       <StrPro
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         inputIdx={formData.inputIdx}
@@ -197,6 +217,7 @@ export const FormProvider = (props: Props) => {
     );
     return (
       <Process
+        id={formData.id}
         partType={formData.partType}
         explanation={formData.explanation}
         inputIdx={formData.inputIdx}

--- a/src/components/features/form/formComponents/Data.tsx
+++ b/src/components/features/form/formComponents/Data.tsx
@@ -13,6 +13,7 @@ type Props = {
 export const Data = (props: Props) => {
   const { setCurrentPartType } = useContext(HintContext);
   const { setHintTypeC } = useContext(HintContext);
+  const { setCurrentHintId } = useContext(HintContext);
 
   const { upDateInputArray } = useContext(InputContext);
 
@@ -20,7 +21,7 @@ export const Data = (props: Props) => {
 
   //タイマーに関する処理
   const [count, setCount] = useState<number>(0);
-  const [delay, setDelay] = useState<number>(1000);
+  const [delay] = useState<number>(1000);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const { setCurrentHintStep } = useContext(HintContext);
 
@@ -51,6 +52,7 @@ export const Data = (props: Props) => {
     upDateInputArray(idx, str);
   };
 
+  const formId = props.id;
   const partType = props.partType;
   const explanation = props.explanation;
   return (
@@ -58,6 +60,7 @@ export const Data = (props: Props) => {
       cols={40}
       rows={4}
       onFocus={() => {
+        setCurrentHintId(formId);
         setCurrentPartType(partType);
         setHintTypeC(explanation);
         setIsRunning(true);

--- a/src/components/features/form/formComponents/Data.tsx
+++ b/src/components/features/form/formComponents/Data.tsx
@@ -4,6 +4,7 @@ import { InputContext } from "../InputArrayProvider";
 import useInterval from "../hooks/useinterval";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   inputIdx: number;

--- a/src/components/features/form/formComponents/Define.tsx
+++ b/src/components/features/form/formComponents/Define.tsx
@@ -4,6 +4,7 @@ import { InputContext } from "../InputArrayProvider";
 import useInterval from "../hooks/useinterval";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   inputIdx: number;

--- a/src/components/features/form/formComponents/Define.tsx
+++ b/src/components/features/form/formComponents/Define.tsx
@@ -13,6 +13,7 @@ type Props = {
 export const Define = (props: Props) => {
   const { setCurrentPartType } = useContext(HintContext);
   const { setHintTypeC } = useContext(HintContext);
+  const { setCurrentHintId } = useContext(HintContext);
 
   const { upDateInputArray } = useContext(InputContext);
 
@@ -20,7 +21,7 @@ export const Define = (props: Props) => {
 
   //タイマーに関する処理
   const [count, setCount] = useState<number>(0);
-  const [delay, setDelay] = useState<number>(1000);
+  const [delay] = useState<number>(1000);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const { setCurrentHintStep } = useContext(HintContext);
 
@@ -51,6 +52,7 @@ export const Define = (props: Props) => {
     upDateInputArray(idx, str);
   };
 
+  const formId = props.id;
   const partType = props.partType;
   const explanation = props.explanation;
   return (
@@ -58,6 +60,7 @@ export const Define = (props: Props) => {
       cols={40}
       rows={4}
       onFocus={() => {
+        setCurrentHintId(formId);
         setCurrentPartType(partType);
         setHintTypeC(explanation);
         setIsRunning(true);

--- a/src/components/features/form/formComponents/Else.tsx
+++ b/src/components/features/form/formComponents/Else.tsx
@@ -1,8 +1,10 @@
+import { child } from "firebase/database";
 import { FormData } from "../../../types/formData";
 import { FormProvider } from "../FormProvider";
 import { Process } from "./Process";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   childrenPart: string | FormData[];
@@ -19,7 +21,7 @@ export const Else = (props: Props) => {
     alert(
       "データ不正エラー：Forフォームの中には、少なくとも１つの子要素が必要です。"
     );
-    return <Process partType="PROC" explanation="" inputIdx={-1} />;
+    return <Process id={-1} partType="PROC" explanation="" inputIdx={-1} />;
   } else if (Array.isArray(props.childrenPart)) {
     const childrenPartArray: FormData[] = props.childrenPart;
     return (
@@ -33,6 +35,7 @@ export const Else = (props: Props) => {
               <>
                 <FormProvider
                   key={childrenPart.id}
+                  id={childrenPart.id}
                   partType={childrenPart.partType}
                   explanation={childrenPart.explanation}
                   childrenPart={childrenPart.childrenPart}

--- a/src/components/features/form/formComponents/Elseif.tsx
+++ b/src/components/features/form/formComponents/Elseif.tsx
@@ -6,6 +6,7 @@ import { HintContext } from "../../hint/HintProvider";
 import useInterval from "../hooks/useinterval";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   childrenPart: string | FormData[];
@@ -59,7 +60,7 @@ export const Elseif = (props: Props) => {
     alert(
       "データ不正エラー：Forフォームの中には、少なくとも１つの子要素が必要です。"
     );
-    return <Process partType="PROC" explanation="" inputIdx={-1} />;
+    return <Process id={-1} partType="PROC" explanation="" inputIdx={-1} />;
   } else if (Array.isArray(props.childrenPart)) {
     const childrenPartArray: FormData[] = props.childrenPart;
     return (
@@ -87,6 +88,7 @@ export const Elseif = (props: Props) => {
               <>
                 <FormProvider
                   key={childrenPart.id}
+                  id={childrenPart.id}
                   partType={childrenPart.partType}
                   explanation={childrenPart.explanation}
                   childrenPart={childrenPart.childrenPart}

--- a/src/components/features/form/formComponents/Elseif.tsx
+++ b/src/components/features/form/formComponents/Elseif.tsx
@@ -16,10 +16,11 @@ type Props = {
 export const Elseif = (props: Props) => {
   const { setCurrentPartType } = useContext(HintContext);
   const { setHintTypeC } = useContext(HintContext);
+  const { setCurrentHintId } = useContext(HintContext);
 
   //タイマーに関する処理
   const [count, setCount] = useState<number>(0);
-  const [delay, setDelay] = useState<number>(1000);
+  const [delay] = useState<number>(1000);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const { setCurrentHintStep } = useContext(HintContext);
 
@@ -44,6 +45,7 @@ export const Elseif = (props: Props) => {
     isRunning ? delay : null
   );
 
+  const formId = props.id;
   const partType = props.partType;
   const explanation = props.explanation;
 
@@ -72,6 +74,7 @@ export const Elseif = (props: Props) => {
             type="text"
             size={5}
             onFocus={() => {
+              setCurrentHintId(formId);
               setCurrentPartType(partType);
               setHintTypeC(explanation);
               setIsRunning(true);

--- a/src/components/features/form/formComponents/For.tsx
+++ b/src/components/features/form/formComponents/For.tsx
@@ -6,6 +6,7 @@ import { HintContext } from "../../hint/HintProvider";
 import useInterval from "../hooks/useinterval";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   childrenPart: string | FormData[];
@@ -59,7 +60,7 @@ export const For = (props: Props) => {
     alert(
       "データ不正エラー：Forフォームの中には、少なくとも１つの子要素が必要です。"
     );
-    return <Process partType="PROC" explanation="" inputIdx={-1} />;
+    return <Process id={-1} partType="PROC" explanation="" inputIdx={-1} />;
   } else if (Array.isArray(props.childrenPart)) {
     const childrenPartArray: FormData[] = props.childrenPart;
     return (
@@ -115,6 +116,7 @@ export const For = (props: Props) => {
               <>
                 <FormProvider
                   key={childrenPart.id}
+                  id={childrenPart.id}
                   partType={childrenPart.partType}
                   explanation={childrenPart.explanation}
                   childrenPart={childrenPart.childrenPart}

--- a/src/components/features/form/formComponents/For.tsx
+++ b/src/components/features/form/formComponents/For.tsx
@@ -16,10 +16,11 @@ type Props = {
 export const For = (props: Props) => {
   const { setCurrentPartType } = useContext(HintContext);
   const { setHintTypeC } = useContext(HintContext);
+  const { setCurrentHintId } = useContext(HintContext);
 
   //タイマーに関する処理
   const [count, setCount] = useState<number>(0);
-  const [delay, setDelay] = useState<number>(1000);
+  const [delay] = useState<number>(1000);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const { setCurrentHintStep } = useContext(HintContext);
 
@@ -44,6 +45,7 @@ export const For = (props: Props) => {
     isRunning ? delay : null
   );
 
+  const formId = props.id;
   const partType = props.partType;
   const explanation = props.explanation;
 
@@ -72,6 +74,7 @@ export const For = (props: Props) => {
             type="text"
             size={5}
             onFocus={() => {
+              setCurrentHintId(formId);
               setCurrentPartType(partType);
               setHintTypeC(explanation);
               setIsRunning(true);

--- a/src/components/features/form/formComponents/Function.tsx
+++ b/src/components/features/form/formComponents/Function.tsx
@@ -15,7 +15,9 @@ type Props = {
 export const Function = (props: Props) => {
   const { setCurrentPartType } = useContext(HintContext);
   const { setHintTypeC } = useContext(HintContext);
+  const { setCurrentHintId } = useContext(HintContext);
 
+  const formId = props.id;
   const partType = props.partType;
   const explanation = props.explanation;
 
@@ -43,6 +45,7 @@ export const Function = (props: Props) => {
             type="text"
             size={5}
             onFocus={() => {
+              setCurrentHintId(formId);
               setCurrentPartType(partType);
               setHintTypeC(explanation);
             }}

--- a/src/components/features/form/formComponents/Function.tsx
+++ b/src/components/features/form/formComponents/Function.tsx
@@ -5,6 +5,7 @@ import { Process } from "./Process";
 import { HintContext } from "../../hint/HintProvider";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   childrenPart: string | FormData[];
@@ -31,7 +32,7 @@ export const Function = (props: Props) => {
     alert(
       "データ不正エラー：Functionフォームの中には、少なくとも１つの子要素が必要です。"
     );
-    return <Process partType="PROC" explanation="" inputIdx={-1} />;
+    return <Process id={-1} partType="PROC" explanation="" inputIdx={-1} />;
   } else if (Array.isArray(props.childrenPart)) {
     const childrenPartArray: FormData[] = props.childrenPart;
     return (
@@ -93,6 +94,7 @@ export const Function = (props: Props) => {
               <>
                 <FormProvider
                   key={childrenPart.id}
+                  id={childrenPart.id}
                   partType={childrenPart.partType}
                   explanation={childrenPart.explanation}
                   childrenPart={childrenPart.childrenPart}

--- a/src/components/features/form/formComponents/If.tsx
+++ b/src/components/features/form/formComponents/If.tsx
@@ -6,6 +6,7 @@ import { HintContext } from "../../hint/HintProvider";
 import useInterval from "../hooks/useinterval";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   childrenPart: string | FormData[];
@@ -59,7 +60,7 @@ export const If = (props: Props) => {
     alert(
       "データ不正エラー：Forフォームの中には、少なくとも１つの子要素が必要です。"
     );
-    return <Process partType="PROC" explanation="" inputIdx={-1} />;
+    return <Process id={-1} partType="PROC" explanation="" inputIdx={-1} />;
   } else if (Array.isArray(props.childrenPart)) {
     const childrenPartArray: FormData[] = props.childrenPart;
     return (
@@ -87,6 +88,7 @@ export const If = (props: Props) => {
               <>
                 <FormProvider
                   key={childrenPart.id}
+                  id={childrenPart.id}
                   partType={childrenPart.partType}
                   explanation={childrenPart.explanation}
                   childrenPart={childrenPart.childrenPart}

--- a/src/components/features/form/formComponents/If.tsx
+++ b/src/components/features/form/formComponents/If.tsx
@@ -16,10 +16,11 @@ type Props = {
 export const If = (props: Props) => {
   const { setCurrentPartType } = useContext(HintContext);
   const { setHintTypeC } = useContext(HintContext);
+  const { setCurrentHintId } = useContext(HintContext);
 
   //タイマーに関する処理
   const [count, setCount] = useState<number>(0);
-  const [delay, setDelay] = useState<number>(1000);
+  const [delay] = useState<number>(1000);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const { setCurrentHintStep } = useContext(HintContext);
 
@@ -44,6 +45,7 @@ export const If = (props: Props) => {
     isRunning ? delay : null
   );
 
+  const formId = props.id;
   const partType = props.partType;
   const explanation = props.explanation;
 
@@ -72,6 +74,7 @@ export const If = (props: Props) => {
             type="text"
             size={5}
             onFocus={() => {
+              setCurrentHintId(formId);
               setCurrentPartType(partType);
               setHintTypeC(explanation);
               setIsRunning(true);

--- a/src/components/features/form/formComponents/Include.tsx
+++ b/src/components/features/form/formComponents/Include.tsx
@@ -13,6 +13,7 @@ type Props = {
 export const Include = (props: Props) => {
   const { setCurrentPartType } = useContext(HintContext);
   const { setHintTypeC } = useContext(HintContext);
+  const { setCurrentHintId } = useContext(HintContext);
 
   const { upDateInputArray } = useContext(InputContext);
 
@@ -20,7 +21,7 @@ export const Include = (props: Props) => {
 
   //タイマーに関する処理
   const [count, setCount] = useState<number>(0);
-  const [delay, setDelay] = useState<number>(1000);
+  const [delay] = useState<number>(1000);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const { setCurrentHintStep } = useContext(HintContext);
 
@@ -51,6 +52,7 @@ export const Include = (props: Props) => {
     upDateInputArray(idx, str);
   };
 
+  const formId = props.id;
   const partType = props.partType;
   const explanation = props.explanation;
   return (
@@ -58,6 +60,7 @@ export const Include = (props: Props) => {
       cols={40}
       rows={4}
       onFocus={() => {
+        setCurrentHintId(formId);
         setCurrentPartType(partType);
         setHintTypeC(explanation);
         setIsRunning(true);

--- a/src/components/features/form/formComponents/Include.tsx
+++ b/src/components/features/form/formComponents/Include.tsx
@@ -4,6 +4,7 @@ import { InputContext } from "../InputArrayProvider";
 import useInterval from "../hooks/useinterval";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   inputIdx: number;

--- a/src/components/features/form/formComponents/Input.tsx
+++ b/src/components/features/form/formComponents/Input.tsx
@@ -4,6 +4,7 @@ import { InputContext } from "../InputArrayProvider";
 import useInterval from "../hooks/useinterval";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   inputIdx: number;

--- a/src/components/features/form/formComponents/Input.tsx
+++ b/src/components/features/form/formComponents/Input.tsx
@@ -13,6 +13,7 @@ type Props = {
 export const Input = (props: Props) => {
   const { setCurrentPartType } = useContext(HintContext);
   const { setHintTypeC } = useContext(HintContext);
+  const { setCurrentHintId } = useContext(HintContext);
 
   const { upDateInputArray } = useContext(InputContext);
 
@@ -51,6 +52,7 @@ export const Input = (props: Props) => {
     upDateInputArray(idx, str);
   };
 
+  const formId = props.id;
   const partType = props.partType;
   const explanation = props.explanation;
   return (
@@ -58,6 +60,7 @@ export const Input = (props: Props) => {
       cols={40}
       rows={4}
       onFocus={() => {
+        setCurrentHintId(formId);
         setCurrentPartType(partType);
         setHintTypeC(explanation);
         setIsRunning(true);

--- a/src/components/features/form/formComponents/Main.tsx
+++ b/src/components/features/form/formComponents/Main.tsx
@@ -3,6 +3,7 @@ import { FormProvider } from "../FormProvider";
 import { Process } from "./Process";
 
 type Props = {
+  id: number;
   partType: string;
   childrenPart: string | FormData[];
   inputIdx: number;
@@ -18,7 +19,7 @@ export const Main = (props: Props) => {
     alert(
       "データ不正エラー：Functionフォームの中には、少なくとも１つの子要素が必要です。"
     );
-    return <Process partType="PROC" explanation="" inputIdx={-1} />;
+    return <Process id={-1} partType="PROC" explanation="" inputIdx={-1} />;
   } else if (Array.isArray(props.childrenPart)) {
     const childrenPartArray: FormData[] = props.childrenPart;
     return (
@@ -30,6 +31,7 @@ export const Main = (props: Props) => {
               <>
                 <FormProvider
                   key={childrenPart.id}
+                  id={childrenPart.id}
                   partType={childrenPart.partType}
                   explanation={childrenPart.explanation}
                   childrenPart={childrenPart.childrenPart}

--- a/src/components/features/form/formComponents/Output.tsx
+++ b/src/components/features/form/formComponents/Output.tsx
@@ -4,6 +4,7 @@ import { InputContext } from "../InputArrayProvider";
 import useInterval from "../hooks/useinterval";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   inputIdx: number;

--- a/src/components/features/form/formComponents/Output.tsx
+++ b/src/components/features/form/formComponents/Output.tsx
@@ -13,6 +13,7 @@ type Props = {
 export const Output = (props: Props) => {
   const { setCurrentPartType } = useContext(HintContext);
   const { setHintTypeC } = useContext(HintContext);
+  const { setCurrentHintId } = useContext(HintContext);
 
   const { upDateInputArray } = useContext(InputContext);
 
@@ -20,7 +21,7 @@ export const Output = (props: Props) => {
 
   //タイマーに関する処理
   const [count, setCount] = useState<number>(0);
-  const [delay, setDelay] = useState<number>(1000);
+  const [delay] = useState<number>(1000);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const { setCurrentHintStep } = useContext(HintContext);
 
@@ -51,6 +52,7 @@ export const Output = (props: Props) => {
     upDateInputArray(idx, str);
   };
 
+  const formId = props.id;
   const partType = props.partType;
   const explanation = props.explanation;
   return (
@@ -58,6 +60,7 @@ export const Output = (props: Props) => {
       cols={40}
       rows={4}
       onFocus={() => {
+        setCurrentHintId(formId);
         setCurrentPartType(partType);
         setHintTypeC(explanation);
         setIsRunning(true);

--- a/src/components/features/form/formComponents/Process.tsx
+++ b/src/components/features/form/formComponents/Process.tsx
@@ -4,6 +4,7 @@ import { InputContext } from "../InputArrayProvider";
 import useInterval from "../hooks/useinterval";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   inputIdx: number;

--- a/src/components/features/form/formComponents/Process.tsx
+++ b/src/components/features/form/formComponents/Process.tsx
@@ -13,6 +13,7 @@ type Props = {
 export const Process = (props: Props) => {
   const { setCurrentPartType } = useContext(HintContext);
   const { setHintTypeC } = useContext(HintContext);
+  const { setCurrentHintId } = useContext(HintContext);
 
   const { upDateInputArray } = useContext(InputContext);
 
@@ -20,7 +21,7 @@ export const Process = (props: Props) => {
 
   //タイマーに関する処理
   const [count, setCount] = useState<number>(0);
-  const [delay, setDelay] = useState<number>(1000);
+  const [delay] = useState<number>(1000);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const { setCurrentHintStep } = useContext(HintContext);
 
@@ -51,6 +52,7 @@ export const Process = (props: Props) => {
     upDateInputArray(idx, str);
   };
 
+  const formId = props.id;
   const partType = props.partType;
   const explanation = props.explanation;
   return (
@@ -58,6 +60,7 @@ export const Process = (props: Props) => {
       cols={40}
       rows={4}
       onFocus={() => {
+        setCurrentHintId(formId);
         setCurrentPartType(partType);
         setHintTypeC(explanation);
         setIsRunning(true);

--- a/src/components/features/form/formComponents/StrDec.tsx
+++ b/src/components/features/form/formComponents/StrDec.tsx
@@ -4,6 +4,7 @@ import { InputContext } from "../InputArrayProvider";
 import useInterval from "../hooks/useinterval";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   inputIdx: number;

--- a/src/components/features/form/formComponents/StrDec.tsx
+++ b/src/components/features/form/formComponents/StrDec.tsx
@@ -13,6 +13,7 @@ type Props = {
 export const StrDec = (props: Props) => {
   const { setCurrentPartType } = useContext(HintContext);
   const { setHintTypeC } = useContext(HintContext);
+  const { setCurrentHintId } = useContext(HintContext);
 
   const { upDateInputArray } = useContext(InputContext);
 
@@ -20,7 +21,7 @@ export const StrDec = (props: Props) => {
 
   //タイマーに関する処理
   const [count, setCount] = useState<number>(0);
-  const [delay, setDelay] = useState<number>(1000);
+  const [delay] = useState<number>(1000);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const { setCurrentHintStep } = useContext(HintContext);
 
@@ -51,6 +52,7 @@ export const StrDec = (props: Props) => {
     upDateInputArray(idx, str);
   };
 
+  const formId = props.id;
   const partType = props.partType;
   const explanation = props.explanation;
   return (
@@ -58,6 +60,7 @@ export const StrDec = (props: Props) => {
       cols={40}
       rows={4}
       onFocus={() => {
+        setCurrentHintId(formId);
         setCurrentPartType(partType);
         setHintTypeC(explanation);
         setIsRunning(true);

--- a/src/components/features/form/formComponents/StrIn.tsx
+++ b/src/components/features/form/formComponents/StrIn.tsx
@@ -4,6 +4,7 @@ import { InputContext } from "../InputArrayProvider";
 import useInterval from "../hooks/useinterval";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   inputIdx: number;

--- a/src/components/features/form/formComponents/StrIn.tsx
+++ b/src/components/features/form/formComponents/StrIn.tsx
@@ -13,6 +13,7 @@ type Props = {
 export const StrIn = (props: Props) => {
   const { setCurrentPartType } = useContext(HintContext);
   const { setHintTypeC } = useContext(HintContext);
+  const { setCurrentHintId } = useContext(HintContext);
 
   const { upDateInputArray } = useContext(InputContext);
 
@@ -20,7 +21,7 @@ export const StrIn = (props: Props) => {
 
   //タイマーに関する処理
   const [count, setCount] = useState<number>(0);
-  const [delay, setDelay] = useState<number>(1000);
+  const [delay] = useState<number>(1000);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const { setCurrentHintStep } = useContext(HintContext);
 
@@ -51,6 +52,7 @@ export const StrIn = (props: Props) => {
     upDateInputArray(idx, str);
   };
 
+  const formId = props.id;
   const partType = props.partType;
   const explanation = props.explanation;
   return (
@@ -58,6 +60,7 @@ export const StrIn = (props: Props) => {
       cols={40}
       rows={4}
       onFocus={() => {
+        setCurrentHintId(formId);
         setCurrentPartType(partType);
         setHintTypeC(explanation);
         setIsRunning(true);

--- a/src/components/features/form/formComponents/StrPro.tsx
+++ b/src/components/features/form/formComponents/StrPro.tsx
@@ -4,6 +4,7 @@ import { InputContext } from "../InputArrayProvider";
 import useInterval from "../hooks/useinterval";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   inputIdx: number;

--- a/src/components/features/form/formComponents/StrPro.tsx
+++ b/src/components/features/form/formComponents/StrPro.tsx
@@ -13,6 +13,7 @@ type Props = {
 export const StrPro = (props: Props) => {
   const { setCurrentPartType } = useContext(HintContext);
   const { setHintTypeC } = useContext(HintContext);
+  const { setCurrentHintId } = useContext(HintContext);
 
   const { upDateInputArray } = useContext(InputContext);
 
@@ -51,6 +52,7 @@ export const StrPro = (props: Props) => {
     upDateInputArray(idx, str);
   };
 
+  const formId = props.id;
   const partType = props.partType;
   const explanation = props.explanation;
   return (
@@ -58,6 +60,7 @@ export const StrPro = (props: Props) => {
       cols={40}
       rows={4}
       onFocus={() => {
+        setCurrentHintId(formId);
         setCurrentPartType(partType);
         setHintTypeC(explanation);
         setIsRunning(true);

--- a/src/components/features/form/formComponents/Struct.tsx
+++ b/src/components/features/form/formComponents/Struct.tsx
@@ -13,6 +13,7 @@ type Props = {
 export const Struct = (props: Props) => {
   const { setCurrentPartType } = useContext(HintContext);
   const { setHintTypeC } = useContext(HintContext);
+  const { setCurrentHintId } = useContext(HintContext);
 
   const [input, setInput] = useState<string>("");
 
@@ -20,7 +21,7 @@ export const Struct = (props: Props) => {
 
   //タイマーに関する処理
   const [count, setCount] = useState<number>(0);
-  const [delay, setDelay] = useState<number>(1000);
+  const [delay] = useState<number>(1000);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const { setCurrentHintStep } = useContext(HintContext);
 
@@ -51,6 +52,7 @@ export const Struct = (props: Props) => {
     upDateInputArray(idx, str);
   };
 
+  const formId = props.id;
   const partType = props.partType;
   const explanation = props.explanation;
 
@@ -71,6 +73,7 @@ export const Struct = (props: Props) => {
           type="text"
           size={5}
           onFocus={() => {
+            setCurrentHintId(formId);
             setCurrentPartType(partType);
             setHintTypeC(explanation);
             setIsRunning(true);

--- a/src/components/features/form/formComponents/Struct.tsx
+++ b/src/components/features/form/formComponents/Struct.tsx
@@ -4,6 +4,7 @@ import { InputContext } from "../InputArrayProvider";
 import useInterval from "../hooks/useinterval";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   inputIdx: number;

--- a/src/components/features/form/formComponents/StructIn.tsx
+++ b/src/components/features/form/formComponents/StructIn.tsx
@@ -13,6 +13,7 @@ type Props = {
 export const StructIn = (props: Props) => {
   const { setCurrentPartType } = useContext(HintContext);
   const { setHintTypeC } = useContext(HintContext);
+  const { setCurrentHintId } = useContext(HintContext);
 
   const { upDateInputArray } = useContext(InputContext);
 
@@ -20,7 +21,7 @@ export const StructIn = (props: Props) => {
 
   //タイマーに関する処理
   const [count, setCount] = useState<number>(0);
-  const [delay, setDelay] = useState<number>(1000);
+  const [delay] = useState<number>(1000);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const { setCurrentHintStep } = useContext(HintContext);
 
@@ -51,6 +52,7 @@ export const StructIn = (props: Props) => {
     upDateInputArray(idx, str);
   };
 
+  const formId = props.id;
   const partType = props.partType;
   const explanation = props.explanation;
   return (
@@ -58,6 +60,7 @@ export const StructIn = (props: Props) => {
       cols={40}
       rows={4}
       onFocus={() => {
+        setCurrentHintId(formId);
         setCurrentPartType(partType);
         setHintTypeC(explanation);
         setIsRunning(true);

--- a/src/components/features/form/formComponents/StructIn.tsx
+++ b/src/components/features/form/formComponents/StructIn.tsx
@@ -4,6 +4,7 @@ import { InputContext } from "../InputArrayProvider";
 import useInterval from "../hooks/useinterval";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   inputIdx: number;

--- a/src/components/features/form/formComponents/StructOut.tsx
+++ b/src/components/features/form/formComponents/StructOut.tsx
@@ -4,6 +4,7 @@ import { InputContext } from "../InputArrayProvider";
 import useInterval from "../hooks/useinterval";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   inputIdx: number;

--- a/src/components/features/form/formComponents/StructOut.tsx
+++ b/src/components/features/form/formComponents/StructOut.tsx
@@ -13,6 +13,7 @@ type Props = {
 export const StructOut = (props: Props) => {
   const { setCurrentPartType } = useContext(HintContext);
   const { setHintTypeC } = useContext(HintContext);
+  const { setCurrentHintId } = useContext(HintContext);
 
   const { upDateInputArray } = useContext(InputContext);
 
@@ -20,7 +21,7 @@ export const StructOut = (props: Props) => {
 
   //タイマーに関する処理
   const [count, setCount] = useState<number>(0);
-  const [delay, setDelay] = useState<number>(1000);
+  const [delay] = useState<number>(1000);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const { setCurrentHintStep } = useContext(HintContext);
 
@@ -51,6 +52,7 @@ export const StructOut = (props: Props) => {
     upDateInputArray(idx, str);
   };
 
+  const formId = props.id;
   const partType = props.partType;
   const explanation = props.explanation;
   return (
@@ -58,6 +60,7 @@ export const StructOut = (props: Props) => {
       cols={40}
       rows={4}
       onFocus={() => {
+        setCurrentHintId(formId);
         setCurrentPartType(partType);
         setHintTypeC(explanation);
         setIsRunning(true);

--- a/src/components/features/form/formComponents/While.tsx
+++ b/src/components/features/form/formComponents/While.tsx
@@ -16,10 +16,11 @@ type Props = {
 export const While = (props: Props) => {
   const { setCurrentPartType } = useContext(HintContext);
   const { setHintTypeC } = useContext(HintContext);
+  const { setCurrentHintId } = useContext(HintContext);
 
   //タイマーに関する処理
   const [count, setCount] = useState<number>(0);
-  const [delay, setDelay] = useState<number>(1000);
+  const [delay] = useState<number>(1000);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const { setCurrentHintStep } = useContext(HintContext);
 
@@ -44,6 +45,7 @@ export const While = (props: Props) => {
     isRunning ? delay : null
   );
 
+  const formId = props.id;
   const partType = props.partType;
   const explanation = props.explanation;
 
@@ -72,6 +74,7 @@ export const While = (props: Props) => {
             type="text"
             size={5}
             onFocus={() => {
+              setCurrentHintId(formId);
               setCurrentPartType(partType);
               setHintTypeC(explanation);
               setIsRunning(true);

--- a/src/components/features/form/formComponents/While.tsx
+++ b/src/components/features/form/formComponents/While.tsx
@@ -6,6 +6,7 @@ import { HintContext } from "../../hint/HintProvider";
 import useInterval from "../hooks/useinterval";
 
 type Props = {
+  id: number;
   partType: string;
   explanation: string;
   childrenPart: string | FormData[];
@@ -59,7 +60,7 @@ export const While = (props: Props) => {
     alert(
       "データ不正エラー：Forフォームの中には、少なくとも１つの子要素が必要です。"
     );
-    return <Process partType="PROC" explanation="" inputIdx={-1} />;
+    return <Process id={-1} partType="PROC" explanation="" inputIdx={-1} />;
   } else if (Array.isArray(props.childrenPart)) {
     const childrenPartArray: FormData[] = props.childrenPart;
     return (
@@ -87,6 +88,7 @@ export const While = (props: Props) => {
               <>
                 <FormProvider
                   key={childrenPart.id}
+                  id={childrenPart.id}
                   partType={childrenPart.partType}
                   explanation={childrenPart.explanation}
                   childrenPart={childrenPart.childrenPart}

--- a/src/components/features/hint/HintProvider.tsx
+++ b/src/components/features/hint/HintProvider.tsx
@@ -5,6 +5,8 @@ export const HintContext = createContext(
   {} as {
     currentPartType: string;
     setCurrentPartType: Dispatch<SetStateAction<string>>;
+    currentHintId: number;
+    setCurrentHintId: Dispatch<SetStateAction<number>>;
     currentHintStep: number;
     setCurrentHintStep: Dispatch<SetStateAction<number>>;
     hintTypeC: string;
@@ -21,6 +23,7 @@ export const HintProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const [currentPartType, setCurrentPartType] = useState<string>("FOR");
   const [hintTypeC, setHintTypeC] = useState<string>("テストヒントC");
+  const [currentHintId, setCurrentHintId] = useState<number>(1);
   const [currentHintStep, setCurrentHintStep] = useState<number>(-1);
   const [hintFBArray, setHintFBArray] = useState<HintFBData[]>([]);
 
@@ -39,6 +42,8 @@ export const HintProvider: React.FC<{ children: React.ReactNode }> = ({
       value={{
         currentPartType,
         setCurrentPartType,
+        currentHintId,
+        setCurrentHintId,
         currentHintStep,
         setCurrentHintStep,
         hintTypeC,

--- a/src/components/features/hint/HintProvider.tsx
+++ b/src/components/features/hint/HintProvider.tsx
@@ -30,7 +30,7 @@ export const HintProvider: React.FC<{ children: React.ReactNode }> = ({
   const appendHintFBArray = (step: number) => {
     //console.log("FB配列更新前: " + JSON.stringify(hintFBArray));
     const newHintFBData: HintFBData = {
-      id: 0,
+      id: currentHintId,
       partType: currentPartType,
       hintStep: step,
     };


### PR DESCRIPTION
# 変更
* HintProviderに、現在のヒントを保持するグローバルステートを用意した。
* currentHintIdをFBとして保存する様にした。
* 全てのコンポーネントに、propsにidを渡す様にした。
* フォームをフォーカスした時に、currentHintIdを更新する様にした。

# テスト
* フォーム画面で一定の操作をした後、データを確認してfbDataにidが正しく記録されていることを確認した。

# issue
closed #59 