### PR TITLE
保存モーダルの名前の空チェックをする様にした。

### DIFF
--- a/src/components/features/FormBase.tsx
+++ b/src/components/features/FormBase.tsx
@@ -33,8 +33,10 @@ export const FormBase = () => {
   const { hintFBArray } = useContext(HintContext);
   const { inputArray } = useContext(InputContext);
 
-  //フォームの名前の入力欄
+  //保存モーダル
   const [userName, setUserName] = useState<string>("");
+  const [error, setError] = useState<boolean>(false);
+  const [helper, setHelper] = useState<string>("");
 
   const handleClickOpen = () => {
     setDialogOpen(true);
@@ -56,6 +58,14 @@ export const FormBase = () => {
   }, []);
 
   const saveLearningData = (userName: string) => {
+    //入力がない場合はエラーを出す
+    if (userName == "") {
+      setError(true);
+      setHelper("名前の入力は必須です。");
+      return;
+    }
+    setError(false);
+    setHelper("");
     //リクエストパラメータのフォーム名を取得し、フォームを取得する
     const url = new URL(window.location.href);
     const formName = url.searchParams.get("form");
@@ -147,6 +157,8 @@ export const FormBase = () => {
             value={userName}
             onChange={(event) => setUserName(event.target.value)}
             sx={{ width: "60%" }}
+            error={error}
+            helperText={helper}
           />
         </DialogContent>
         <DialogActions>


### PR DESCRIPTION
# 変更
* テキストフィールドのerrorとhelperText用にstateを用意した。
* 「保存」ボタンを押したときに、TextFieldが空欄だったらerrorとhelperTextを表示して保存できない様にした。

# テスト
* 保存モーダルで名前を入れずに「保存」ボタンを押したら、エラーが出て保存できないことを確認した
* 名前を入れて、再度「保存」ボタンを押したら、エラーが消えて正しく保存できることを確認した。

# issue
closed #67 

