### PR TITLE
フォームの一覧をカード形式で表示できるようにした。

### DIFF
--- a/src/components/features/leaning/FormCard.tsx
+++ b/src/components/features/leaning/FormCard.tsx
@@ -18,8 +18,7 @@ export const FormCard = (props: Props) => {
     <div>
       <Card sx={{ maxWidth: 345 }}>
         <CardMedia
-          sx={{ height: 140 }}
-          image="/static/images/cards/contemplative-reptile.jpg"
+          sx={{ height: 140, backgroundColor: "#a1d43b" }}
           title="green iguana"
         />
         <CardContent>
@@ -31,7 +30,11 @@ export const FormCard = (props: Props) => {
           </Typography>
         </CardContent>
         <CardActions>
-          <Button size="small" onClick={() => window.open(props.url, "_blank")}>
+          <Button
+            size="medium"
+            variant="contained"
+            onClick={() => window.open(props.url, "_blank")}
+          >
             始める
           </Button>
         </CardActions>

--- a/src/components/features/leaning/FormCard.tsx
+++ b/src/components/features/leaning/FormCard.tsx
@@ -7,7 +7,13 @@ import {
   Typography,
 } from "@mui/material";
 
-export const FormCard = () => {
+type Props = {
+  title: string;
+  description: string;
+  url: string;
+};
+
+export const FormCard = (props: Props) => {
   return (
     <div>
       <Card sx={{ maxWidth: 345 }}>
@@ -18,16 +24,16 @@ export const FormCard = () => {
         />
         <CardContent>
           <Typography gutterBottom variant="h5" component="div">
-            Lizard
+            {props.title}
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            Lizards are a widespread group of squamate reptiles, with over 6,000
-            species, ranging across all continents except Antarctica
+            {props.description}
           </Typography>
         </CardContent>
         <CardActions>
-          <Button size="small">Share</Button>
-          <Button size="small">Learn More</Button>
+          <Button size="small" onClick={() => window.open(props.url, "_blank")}>
+            始める
+          </Button>
         </CardActions>
       </Card>
     </div>

--- a/src/components/features/leaning/FormCard.tsx
+++ b/src/components/features/leaning/FormCard.tsx
@@ -1,0 +1,35 @@
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  CardMedia,
+  Typography,
+} from "@mui/material";
+
+export const FormCard = () => {
+  return (
+    <div>
+      <Card sx={{ maxWidth: 345 }}>
+        <CardMedia
+          sx={{ height: 140 }}
+          image="/static/images/cards/contemplative-reptile.jpg"
+          title="green iguana"
+        />
+        <CardContent>
+          <Typography gutterBottom variant="h5" component="div">
+            Lizard
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Lizards are a widespread group of squamate reptiles, with over 6,000
+            species, ranging across all continents except Antarctica
+          </Typography>
+        </CardContent>
+        <CardActions>
+          <Button size="small">Share</Button>
+          <Button size="small">Learn More</Button>
+        </CardActions>
+      </Card>
+    </div>
+  );
+};

--- a/src/components/features/leaning/Learning.tsx
+++ b/src/components/features/leaning/Learning.tsx
@@ -1,8 +1,23 @@
-import { Box, Button } from "@mui/material";
+import { Box, Button, Grid } from "@mui/material";
+import { FormCard } from "./FormCard";
 
 export const Learning = () => {
   return (
     <Box sx={{ height: "1000px", paddingTop: "100px" }}>
+      <Grid container spacing={1}>
+        <Grid item xs={3}>
+          <FormCard />
+        </Grid>
+        <Grid item xs={3}>
+          <FormCard />
+        </Grid>
+        <Grid item xs={3}>
+          <FormCard />
+        </Grid>
+        <Grid item xs={3}>
+          <FormCard />
+        </Grid>
+      </Grid>
       <Button
         size="large"
         onClick={() => {

--- a/src/components/features/leaning/Learning.tsx
+++ b/src/components/features/leaning/Learning.tsx
@@ -1,42 +1,39 @@
 import { Box, Button, Grid, Typography } from "@mui/material";
 import { FormCard } from "./FormCard";
+import { FormCardList } from "../../types/formCardList";
 
 export const Learning = () => {
+  const formCardList: FormCardList[] = [
+    {
+      id: 1,
+      title: "Experiment1",
+      description: "実験用のフォーム1です。",
+      url: "/form?form=experiment1",
+    },
+    {
+      id: 2,
+      title: "Experiment2",
+      description: "実験用のフォーム2です。",
+      url: "/form?form=experiment2",
+    },
+  ];
+
   return (
     <Box sx={{ height: "1000px", paddingTop: "160px" }}>
       <Typography variant="h4" component="div" gutterBottom>
         すべてのフォーム
       </Typography>
       <Grid container spacing={1}>
-        <Grid item xs={3}>
-          <FormCard />
-        </Grid>
-        <Grid item xs={3}>
-          <FormCard />
-        </Grid>
-        <Grid item xs={3}>
-          <FormCard />
-        </Grid>
-        <Grid item xs={3}>
-          <FormCard />
-        </Grid>
+        {formCardList.map((formCard) => (
+          <Grid item xs={3} key={formCard.id}>
+            <FormCard
+              title={formCard.title}
+              description={formCard.description}
+              url={formCard.url}
+            />
+          </Grid>
+        ))}
       </Grid>
-      <Button
-        size="large"
-        onClick={() => {
-          window.open("/form?form=experiment1", "_blank");
-        }}
-      >
-        実験用フォーム1
-      </Button>
-      <Button
-        size="large"
-        onClick={() => {
-          window.open("/form?form=experiment2", "_blank");
-        }}
-      >
-        実験用フォーム2
-      </Button>
     </Box>
   );
 };

--- a/src/components/features/leaning/Learning.tsx
+++ b/src/components/features/leaning/Learning.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Grid, Typography } from "@mui/material";
+import { Box, Grid, Typography } from "@mui/material";
 import { FormCard } from "./FormCard";
 import { FormCardList } from "../../types/formCardList";
 
@@ -20,7 +20,12 @@ export const Learning = () => {
 
   return (
     <Box sx={{ height: "1000px", paddingTop: "160px" }}>
-      <Typography variant="h4" component="div" gutterBottom>
+      <Typography
+        variant="h4"
+        component="div"
+        gutterBottom
+        sx={{ fontWeight: "bold" }}
+      >
         すべてのフォーム
       </Typography>
       <Grid container spacing={1}>

--- a/src/components/features/leaning/Learning.tsx
+++ b/src/components/features/leaning/Learning.tsx
@@ -1,9 +1,12 @@
-import { Box, Button, Grid } from "@mui/material";
+import { Box, Button, Grid, Typography } from "@mui/material";
 import { FormCard } from "./FormCard";
 
 export const Learning = () => {
   return (
-    <Box sx={{ height: "1000px", paddingTop: "100px" }}>
+    <Box sx={{ height: "1000px", paddingTop: "160px" }}>
+      <Typography variant="h4" component="div" gutterBottom>
+        すべてのフォーム
+      </Typography>
       <Grid container spacing={1}>
         <Grid item xs={3}>
           <FormCard />

--- a/src/components/types/formCardList.ts
+++ b/src/components/types/formCardList.ts
@@ -1,0 +1,6 @@
+export type FormCardList = {
+  id: number;
+  title: string;
+  description: string;
+  url: string;
+};


### PR DESCRIPTION
# 変更
* MUIのCardを使って、フォームの一覧を表示するようにした（FormCard.tsx）
* フォームの選択肢の情報は、`formCardList`で管理するようにした（Learning.tsx）

# テスト
サーバを起動し、フォーム一覧画面に移動すると、正しく表示できことを確認した。

# issue
#100 