### PR TITLE
フォームの種類ごとに、分析結果を表示できるようにした。

### DIFF
--- a/src/components/features/analytics/BarGraph.tsx
+++ b/src/components/features/analytics/BarGraph.tsx
@@ -24,6 +24,9 @@ ChartJS.register(
 
 export const BarGraph = () => {
   const [forcasedSpeed, setForcasedSpeed] = React.useState<number | null>(null);
+  const [forcasedBrankName, setForcasedBrankName] = React.useState<
+    string | null
+  >(null);
 
   const analyzedData = [
     {
@@ -76,8 +79,10 @@ export const BarGraph = () => {
       if (activeElements.length > 0) {
         const index = activeElements[0].index;
         setForcasedSpeed(graphData.datasets[0].data[index]);
+        setForcasedBrankName(graphData.labels[index]);
       } else {
         setForcasedSpeed(null);
+        setForcasedBrankName(null);
       }
     },
   };
@@ -89,7 +94,7 @@ export const BarGraph = () => {
         <Box sx={{ background: "#FFFDE7", borderRadius: 2, padding: "5px" }}>
           <Stack spacing={2} direction={"row"}>
             <Typography variant="h6" sx={{ fontWeight: "bold" }}>
-              変数・配列宣言
+              {forcasedBrankName ? forcasedBrankName : "--"} 秒
             </Typography>
             <Typography variant="h6">
               速度：{forcasedSpeed ? forcasedSpeed : "--"}個/秒

--- a/src/components/features/analytics/BarGraph.tsx
+++ b/src/components/features/analytics/BarGraph.tsx
@@ -1,0 +1,104 @@
+import { Line } from "react-chartjs-2";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import React from "react";
+import { Box, Stack, Typography } from "@mui/material";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+export const BarGraph = () => {
+  const [forcasedSpeed, setForcasedSpeed] = React.useState<number | null>(null);
+
+  const analyzedData = [
+    {
+      label: "打鍵速度",
+      labelEn: "speed",
+      data: [2.5, 3.0, 1.0, 4.2, 1.6, 2.0],
+      borderColor: "rgb(75, 192, 192)",
+    },
+    {
+      label: "削除率",
+      labelEn: "delete-rate",
+      data: [28, 48, 40, 19, 86, 27],
+      borderColor: "rgb(255, 99, 132)",
+    },
+  ];
+
+  const labels = ["0", "60", "120", "150", "180", "210"];
+  const graphData = {
+    labels: labels,
+    datasets: [
+      {
+        label: "打鍵速度",
+        data: [2.5, 3.0, 1.0, 4.2, 1.6, 2.0],
+        borderColor: "rgb(75, 192, 192)",
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    interaction: {
+      mode: "index" as const,
+      intersect: false,
+    },
+    stacked: false,
+    plugins: {
+      title: {
+        display: true,
+        text: "打鍵速度推移",
+      },
+    },
+    scales: {
+      y: {
+        type: "linear" as const,
+        display: true,
+        position: "left" as const,
+      },
+    },
+    onHover: (_: any, activeElements: any) => {
+      if (activeElements.length > 0) {
+        const index = activeElements[0].index;
+        setForcasedSpeed(graphData.datasets[0].data[index]);
+      } else {
+        setForcasedSpeed(null);
+      }
+    },
+  };
+
+  return (
+    <div>
+      <Line width={200} height={80} data={graphData} options={options} />
+      <div style={{ marginBottom: "10px" }}>
+        <Box sx={{ background: "#FFFDE7", borderRadius: 2, padding: "5px" }}>
+          <Stack spacing={2} direction={"row"}>
+            <Typography variant="h6" sx={{ fontWeight: "bold" }}>
+              変数・配列宣言
+            </Typography>
+            <Typography variant="h6">
+              速度：{forcasedSpeed ? forcasedSpeed : "--"}個/秒
+            </Typography>
+            <Typography variant="h6">前回比：+2.0個/秒</Typography>
+            <Typography variant="h6">平均比：+2.0個/秒</Typography>
+          </Stack>
+        </Box>
+      </div>
+    </div>
+  );
+};

--- a/src/components/features/analytics/BarGraph.tsx
+++ b/src/components/features/analytics/BarGraph.tsx
@@ -28,21 +28,6 @@ export const BarGraph = () => {
     string | null
   >(null);
 
-  const analyzedData = [
-    {
-      label: "打鍵速度",
-      labelEn: "speed",
-      data: [2.5, 3.0, 1.0, 4.2, 1.6, 2.0],
-      borderColor: "rgb(75, 192, 192)",
-    },
-    {
-      label: "削除率",
-      labelEn: "delete-rate",
-      data: [28, 48, 40, 19, 86, 27],
-      borderColor: "rgb(255, 99, 132)",
-    },
-  ];
-
   const labels = ["0", "60", "120", "150", "180", "210"];
   const graphData = {
     labels: labels,

--- a/src/components/features/analytics/Graph.tsx
+++ b/src/components/features/analytics/Graph.tsx
@@ -1,30 +1,15 @@
-import { Box, Stack, Typography } from "@mui/material";
-import { Line } from "react-chartjs-2";
-import {
-  Chart as ChartJS,
-  CategoryScale,
-  LinearScale,
-  PointElement,
-  LineElement,
-  Title,
-  Tooltip,
-  Legend,
-} from "chart.js";
+import { Stack, Typography } from "@mui/material";
 import { Select, Option } from "@mui/joy";
+import { BarGraph } from "./BarGraph";
 import React from "react";
 
-ChartJS.register(
-  CategoryScale,
-  LinearScale,
-  PointElement,
-  LineElement,
-  Title,
-  Tooltip,
-  Legend,
-);
-
 export const Graph = () => {
-  const [forcasedSpeed, setForcasedSpeed] = React.useState<number | null>(null);
+  const [selectedOption, setSelectedOption] = React.useState("time");
+
+  const handleOptionChange = (event: any, newValue: any) => {
+    setSelectedOption(newValue);
+    console.log(newValue);
+  };
 
   const analyzedData = [
     {
@@ -41,75 +26,18 @@ export const Graph = () => {
     },
   ];
 
-  const labels = ["0", "60", "120", "150", "180", "210"];
-  const graphData = {
-    labels: labels,
-    datasets: [
-      {
-        label: "打鍵速度",
-        data: [2.5, 3.0, 1.0, 4.2, 1.6, 2.0],
-        borderColor: "rgb(75, 192, 192)",
-      },
-    ],
-  };
-
-  const options = {
-    responsive: true,
-    interaction: {
-      mode: "index" as const,
-      intersect: false,
-    },
-    stacked: false,
-    plugins: {
-      title: {
-        display: true,
-        text: "打鍵速度推移",
-      },
-    },
-    scales: {
-      y: {
-        type: "linear" as const,
-        display: true,
-        position: "left" as const,
-      },
-    },
-    onHover: (_: any, activeElements: any) => {
-      if (activeElements.length > 0) {
-        const index = activeElements[0].index;
-        setForcasedSpeed(graphData.datasets[0].data[index]);
-      } else {
-        setForcasedSpeed(null);
-      }
-    },
-  };
-
   return (
     <div>
       <Typography variant="h6" sx={{ color: "#ffffff", background: "#5F94D9" }}>
         区間別分析
       </Typography>
-      <Line width={200} height={80} data={graphData} options={options} />
-      <div style={{ marginBottom: "10px" }}>
-        <Box sx={{ background: "#FFFDE7", borderRadius: 2, padding: "5px" }}>
-          <Stack spacing={2} direction={"row"}>
-            <Typography variant="h6" sx={{ fontWeight: "bold" }}>
-              変数・配列宣言
-            </Typography>
-            <Typography variant="h6">
-              速度：{forcasedSpeed ? forcasedSpeed : "--"}個/秒
-            </Typography>
-            <Typography variant="h6">前回比：+2.0個/秒</Typography>
-            <Typography variant="h6">平均比：+2.0個/秒</Typography>
-          </Stack>
-        </Box>
-      </div>
-
+      {selectedOption === "time" ? <BarGraph /> : null}
       <div>
         <Stack spacing={2} direction="row">
           <div>
             <Stack spacing={2} direction={"row"}>
               <Typography variant="h6">表示方法</Typography>
-              <Select defaultValue="time">
+              <Select value={selectedOption} onChange={handleOptionChange}>
                 <Option value="time">時間による推移</Option>
                 <Option value="blank">空欄ごと</Option>
               </Select>

--- a/src/components/features/analytics/Graph.tsx
+++ b/src/components/features/analytics/Graph.tsx
@@ -2,6 +2,7 @@ import { Stack, Typography } from "@mui/material";
 import { Select, Option } from "@mui/joy";
 import { BarGraph } from "./BarGraph";
 import React from "react";
+import { HorizoBarGraph } from "./HorizoBarGraph";
 
 export const Graph = () => {
   const [selectedOption, setSelectedOption] = React.useState("time");
@@ -31,7 +32,7 @@ export const Graph = () => {
       <Typography variant="h6" sx={{ color: "#ffffff", background: "#5F94D9" }}>
         区間別分析
       </Typography>
-      {selectedOption === "time" ? <BarGraph /> : null}
+      {selectedOption === "time" ? <BarGraph /> : <HorizoBarGraph />}
       <div>
         <Stack spacing={2} direction="row">
           <div>

--- a/src/components/features/analytics/HorizoBarGraph.tsx
+++ b/src/components/features/analytics/HorizoBarGraph.tsx
@@ -14,7 +14,6 @@ import {
 
 import React from "react";
 import { Box, Stack, Typography } from "@mui/material";
-import { set } from "react-hook-form";
 
 ChartJS.register(
   TimeScale,

--- a/src/components/features/analytics/HorizoBarGraph.tsx
+++ b/src/components/features/analytics/HorizoBarGraph.tsx
@@ -1,0 +1,106 @@
+import { Bar } from "react-chartjs-2";
+
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  TimeScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+  ChartOptions,
+} from "chart.js";
+
+import React from "react";
+import { Box, Stack, Typography } from "@mui/material";
+
+ChartJS.register(
+  TimeScale,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+export const HorizoBarGraph = () => {
+  const [forcasedSpeed, setForcasedSpeed] = React.useState<number | null>(null);
+
+  const data = {
+    labels: [
+      "インクルード",
+      "変数・配列宣言",
+      "入力",
+      "処理",
+      "forループ",
+      "出力",
+    ],
+    datasets: [
+      {
+        label: "打鍵速度",
+        data: [1.5, 2.0, 3.0, 0.2, 2.2, 3.9],
+        borderColor: "rgb(255, 99, 132)",
+        backgroundColor: "rgba(255, 99, 132, 0.5)",
+      },
+    ],
+  };
+
+  const options: ChartOptions<"bar"> = {
+    indexAxis: "y",
+    scales: {
+      x: {
+        type: "linear",
+        title: {
+          display: true,
+          text: "打鍵速度",
+        },
+      },
+      y: {
+        title: {
+          display: true,
+          text: "入力欄",
+        },
+      },
+    },
+    onHover: (_: any, activeElements: any) => {
+      if (activeElements.length > 0) {
+        const index = activeElements[0].index;
+        setForcasedSpeed(data.datasets[0].data[index]);
+      } else {
+        setForcasedSpeed(null);
+      }
+    },
+    responsive: true,
+    plugins: {
+      legend: {
+        position: "top",
+      },
+      title: {
+        display: true,
+        text: "入力欄ごとの分析",
+      },
+    },
+  };
+
+  return (
+    <div>
+      <Bar options={options} data={data} />
+      <div style={{ marginBottom: "10px" }}>
+        <Box sx={{ background: "#FFFDE7", borderRadius: 2, padding: "5px" }}>
+          <Stack spacing={2} direction={"row"}>
+            <Typography variant="h6" sx={{ fontWeight: "bold" }}>
+              変数・配列宣言
+            </Typography>
+            <Typography variant="h6">
+              速度：{forcasedSpeed ? forcasedSpeed : "--"}個/秒
+            </Typography>
+            <Typography variant="h6">前回比：+2.0個/秒</Typography>
+            <Typography variant="h6">平均比：+2.0個/秒</Typography>
+          </Stack>
+        </Box>
+      </div>
+    </div>
+  );
+};

--- a/src/components/features/analytics/HorizoBarGraph.tsx
+++ b/src/components/features/analytics/HorizoBarGraph.tsx
@@ -14,6 +14,7 @@ import {
 
 import React from "react";
 import { Box, Stack, Typography } from "@mui/material";
+import { set } from "react-hook-form";
 
 ChartJS.register(
   TimeScale,
@@ -27,6 +28,9 @@ ChartJS.register(
 
 export const HorizoBarGraph = () => {
   const [forcasedSpeed, setForcasedSpeed] = React.useState<number | null>(null);
+  const [forcasedBrankName, setForcasedBrankName] = React.useState<
+    string | null
+  >(null);
 
   const data = {
     labels: [
@@ -68,8 +72,10 @@ export const HorizoBarGraph = () => {
       if (activeElements.length > 0) {
         const index = activeElements[0].index;
         setForcasedSpeed(data.datasets[0].data[index]);
+        setForcasedBrankName(data.labels[index]);
       } else {
         setForcasedSpeed(null);
+        setForcasedBrankName(null);
       }
     },
     responsive: true,
@@ -91,7 +97,7 @@ export const HorizoBarGraph = () => {
         <Box sx={{ background: "#FFFDE7", borderRadius: 2, padding: "5px" }}>
           <Stack spacing={2} direction={"row"}>
             <Typography variant="h6" sx={{ fontWeight: "bold" }}>
-              変数・配列宣言
+              {forcasedBrankName ? forcasedBrankName : "--"}
             </Typography>
             <Typography variant="h6">
               速度：{forcasedSpeed ? forcasedSpeed : "--"}個/秒


### PR DESCRIPTION
# 変更
* グラフの種類ごと（時間による推移、空欄ごと）でコンポーネントを分割した。
* セレクトメニューの切り替えに応じて、上記のコンポーネントを切り替えて表示するようにした。
* 空欄ごとに分析結果を表示するコンポーネント、`HorizoBarGraph.tsx`を作成した。
* グラフでフォーカスした場所の時間や空欄の名前を、グラフ直下の黄色い部分に新たに表示するようにした。
* 不要なインポートや宣言を削除した。

# 確認方法
実際にブラウザで、`/analytics`にアクセスし、正しく切り替え・表示できることを確認した。

# issue
closed #197 