### PR TITLE
シーケンスを時間ごとに分析したグラフを表示できるようにした。

### DIFF
--- a/src/components/features/FormBase.tsx
+++ b/src/components/features/FormBase.tsx
@@ -39,6 +39,9 @@ export const FormBase = () => {
   const [formName, setFormName] = useState<string>("フォーム名"); //TODO: 後日、削除する
   const [formId, setFormId] = useState<string>("");
 
+  //保存済みのrecordId
+  const [recordId, setRecordId] = useState<string>("");
+
   const { hintFBArray } = useContext(HintContext);
   const { inputArray } = useContext(InputContext);
   const { code } = useContext(CodeContext);
@@ -66,7 +69,8 @@ export const FormBase = () => {
 
   //分析結果画面へ遷移
   const jumpToAnalytics = () => {
-    location.href = "/analytics";
+    console.log("recordId: " + recordId);
+    location.href = "/analytics?id=" + recordId;
   };
 
   //ローディングモーダルを閉じる
@@ -129,7 +133,7 @@ export const FormBase = () => {
   const saveLearningData = async () => {
     const url = `${apiBaseUrl}/record`;
     //仮のシーケンスデータを追加
-    initSequenceData();
+    //initSequenceData();
 
     const sampleSeqAnalyze = {
       speed: 50,
@@ -164,10 +168,13 @@ export const FormBase = () => {
               throw new Error("Unknown Error");
           }
         }
+        const data = await res.json();
+        const recordId = data.recordId;
+        setRecordId(recordId);
         handleClickOpen();
       });
     } catch (error) {
-      alert("アップロード中にエラーが発生しました。");
+      alert("A: アップロード中にエラーが発生しました。");
       console.log(error);
     }
   };

--- a/src/components/features/analytics/Analytics.tsx
+++ b/src/components/features/analytics/Analytics.tsx
@@ -17,7 +17,6 @@ import { TestResult } from "./TestResult";
 
 import { useUserData } from "../../common/hooks/useUserData";
 import { useEffect, useState } from "react";
-import { set } from "react-hook-form";
 
 export const Analytics = () => {
   const { getUserData } = useUserData();
@@ -25,7 +24,11 @@ export const Analytics = () => {
 
   //記録データのID
   const [recordId, setRecordId] = useState<string>("");
-  const [recordData, setRecordData] = useState<any>({});
+  const [recordData, setRecordData] = useState<any>({
+    userId: "",
+    formId: "",
+    sequence: [],
+  });
 
   const buttonStyle = {
     color: "#fff",
@@ -232,7 +235,7 @@ export const Analytics = () => {
             <Grid item xs={7}>
               <Grid container direction={"column"} spacing={2}>
                 <Grid item xs={6}>
-                  <Graph />
+                  <Graph sequence={recordData.sequence} />
                 </Grid>
                 <Grid item xs={6}>
                   <ReviewAdovice reviewList={sampleReviewData} />

--- a/src/components/features/analytics/BarGraph.tsx
+++ b/src/components/features/analytics/BarGraph.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
   Legend,
 } from "chart.js";
-import React from "react";
+import React, { useEffect } from "react";
 import { Box, Stack, Typography } from "@mui/material";
 
 ChartJS.register(
@@ -19,26 +19,55 @@ ChartJS.register(
   LineElement,
   Title,
   Tooltip,
-  Legend,
+  Legend
 );
 
-export const BarGraph = () => {
+type Props = {
+  analyzeItemLabel: string;
+  analyzeItemlabelEn: string;
+  analyzeResultList: any;
+};
+
+export const BarGraph = (props: Props) => {
+  const { analyzeItemLabel, analyzeItemlabelEn, analyzeResultList } = props;
   const [forcasedSpeed, setForcasedSpeed] = React.useState<number | null>(null);
   const [forcasedBrankName, setForcasedBrankName] = React.useState<
     string | null
   >(null);
 
-  const labels = ["0", "60", "120", "150", "180", "210"];
-  const graphData = {
-    labels: labels,
-    datasets: [
-      {
-        label: "打鍵速度",
-        data: [2.5, 3.0, 1.0, 4.2, 1.6, 2.0],
-        borderColor: "rgb(75, 192, 192)",
-      },
-    ],
-  };
+  const [graphData, setGraphData] = React.useState<any>({
+    labels: [],
+    datasets: [],
+  });
+
+  useEffect(() => {
+    //analyzeResultListがnullのとき
+    if (analyzeResultList === null) {
+      return;
+    }
+
+    const labels: string[] = [];
+    const data: number[] = [];
+
+    analyzeResultList.forEach((result: any) => {
+      const startTimestamp = result.startTimestamp / 1000;
+      const endTimestamp = result.endTimestamp / 1000;
+      const label = `${startTimestamp} - ${endTimestamp}`;
+      labels.push(label);
+      data.push(result[analyzeItemlabelEn]);
+    });
+
+    setGraphData({
+      labels: labels,
+      datasets: [
+        {
+          label: analyzeItemLabel,
+          data: data,
+          borderColor: "rgb(75, 192, 192)",
+        },
+      ],
+    });
+  }, [analyzeItemLabel, analyzeItemlabelEn, analyzeResultList]);
 
   const options = {
     responsive: true,
@@ -50,7 +79,7 @@ export const BarGraph = () => {
     plugins: {
       title: {
         display: true,
-        text: "打鍵速度推移",
+        text: "時間ごとの分析",
       },
     },
     scales: {

--- a/src/components/features/analytics/BarGraph.tsx
+++ b/src/components/features/analytics/BarGraph.tsx
@@ -19,7 +19,7 @@ ChartJS.register(
   LineElement,
   Title,
   Tooltip,
-  Legend
+  Legend,
 );
 
 type Props = {

--- a/src/components/features/analytics/Graph.tsx
+++ b/src/components/features/analytics/Graph.tsx
@@ -14,6 +14,7 @@ export const Graph = (props: Props) => {
   const { sequence } = props;
 
   const [selectedOption, setSelectedOption] = React.useState("time");
+  const [selectedAnalyzedItem, setSelectedAnalyzedItem] = React.useState(0);
 
   //それぞれの分析結果
   const [analyzeResultListInterval, setAnalyzeResultListInterval] =
@@ -22,6 +23,58 @@ export const Graph = (props: Props) => {
   const handleOptionChange = (event: any, newValue: any) => {
     setSelectedOption(newValue);
   };
+
+  const handleAnalyzedItemChange = (event: any, newValue: any) => {
+    setSelectedAnalyzedItem(newValue);
+    console.log("selectedAnalyzedItem:", newValue);
+  };
+
+  const analyzeItemList = [
+    {
+      label: "データ数",
+      labelEn: "datasCount",
+    },
+    {
+      label: "入力文字数",
+      labelEn: "inputCharLength",
+    },
+    {
+      label: "削除文字数",
+      labelEn: "removedCharLength",
+    },
+    {
+      label: "入力データ数",
+      labelEn: "inputDataCount",
+    },
+    {
+      label: "削除データ数",
+      labelEn: "removedDataCount",
+    },
+    {
+      label: "入力ミス率",
+      labelEn: "missTypeRate",
+    },
+    {
+      label: "打鍵速度",
+      labelEn: "typePerSec",
+    },
+    {
+      label: "書き直し数",
+      labelEn: "totalReInputCnt",
+    },
+    {
+      label: "合計書き直し時間",
+      labelEn: "totalReInputTime",
+    },
+    {
+      label: "書き直し率",
+      labelEn: "reInputRate",
+    },
+    {
+      label: "平均書き直し時間",
+      labelEn: "averageReInputTime",
+    },
+  ];
 
   const analyzedData = [
     {
@@ -91,7 +144,15 @@ export const Graph = (props: Props) => {
       <Typography variant="h6" sx={{ color: "#ffffff", background: "#5F94D9" }}>
         区間別分析
       </Typography>
-      {selectedOption === "time" ? <BarGraph /> : <HorizoBarGraph />}
+      {selectedOption === "time" ? (
+        <BarGraph
+          analyzeItemLabel={analyzeItemList[selectedAnalyzedItem].label}
+          analyzeItemlabelEn={analyzeItemList[selectedAnalyzedItem].labelEn}
+          analyzeResultList={analyzeResultListInterval}
+        />
+      ) : (
+        <HorizoBarGraph />
+      )}
       <div>
         <Stack spacing={2} direction="row">
           <div>
@@ -106,9 +167,12 @@ export const Graph = (props: Props) => {
           <div>
             <Stack spacing={2} direction={"row"}>
               <Typography variant="h6">分析対象</Typography>
-              <Select defaultValue={analyzedData[0].labelEn}>
-                {analyzedData.map((data, index) => (
-                  <Option key={index} value={data.labelEn}>
+              <Select
+                value={selectedAnalyzedItem}
+                onChange={handleAnalyzedItemChange}
+              >
+                {analyzeItemList.map((data, index) => (
+                  <Option key={index} value={index}>
                     {data.label}
                   </Option>
                 ))}


### PR DESCRIPTION
# 変更
* 学習データを記録するときに、`recordId`を受け取って、分析画面に遷移するときにクエリパラメータでidを渡すようにした。
* 分析結果画面で、保存された記録データを取り出し、分析のapiを叩いて分析結果を取得できるようにした。
* 分析結果のデータをグラフに渡して、グラフで扱える形に変換して表示できるようにした。

# issue
closed #194 