### PR TITLE
分析結果画面の平均の出し方などを変更した。

### DIFF
--- a/src/components/features/analytics/BarGraph.tsx
+++ b/src/components/features/analytics/BarGraph.tsx
@@ -27,6 +27,7 @@ type Props = {
   analyzeItemlabelEn: string;
   analyzeResultList: any;
   analyzeResultListGeneral: any;
+  analyzeResultListAverage: any;
   analyzeUnit: string;
 };
 
@@ -36,8 +37,12 @@ export const BarGraph = (props: Props) => {
     analyzeItemlabelEn,
     analyzeResultList,
     analyzeResultListGeneral,
+    analyzeResultListAverage,
     analyzeUnit,
   } = props;
+
+  const [compareWithAverage, setCompareWithAverage] =
+    React.useState<string>("");
 
   const [graphData, setGraphData] = React.useState<any>({
     labels: [],
@@ -71,6 +76,19 @@ export const BarGraph = (props: Props) => {
         },
       ],
     });
+
+    //平均比を計算
+    if (
+      analyzeResultListGeneral !== null &&
+      analyzeResultListAverage !== null
+    ) {
+      const average = analyzeResultListAverage[0][analyzeItemlabelEn];
+      const general = analyzeResultListGeneral[0][analyzeItemlabelEn];
+      const compareResult = general - average;
+      //compareResultの結果を少数第２位までにする
+      const compareResultFixed = compareResult.toFixed(1);
+      setCompareWithAverage(compareResultFixed);
+    }
   }, [analyzeItemLabel, analyzeItemlabelEn, analyzeResultList]);
 
   const options = {
@@ -110,8 +128,16 @@ export const BarGraph = (props: Props) => {
                 : "-"}
               {analyzeUnit}
             </Typography>
-            <Typography variant="h6">平均比：+2.0{analyzeUnit}</Typography>
-            <Typography variant="h6">前回比：+2.0{analyzeUnit}</Typography>
+            <Typography variant="h6">
+              平均比：
+              {Number(compareWithAverage) > 0 ? "+" : ""}
+              {analyzeResultListGeneral !== null &&
+              analyzeResultListAverage !== null
+                ? compareWithAverage
+                : "-"}
+              {analyzeUnit}
+            </Typography>
+            <Typography variant="h6">前回比：---{analyzeUnit}</Typography>
           </Stack>
         </Box>
       </div>

--- a/src/components/features/analytics/BarGraph.tsx
+++ b/src/components/features/analytics/BarGraph.tsx
@@ -19,21 +19,25 @@ ChartJS.register(
   LineElement,
   Title,
   Tooltip,
-  Legend,
+  Legend
 );
 
 type Props = {
   analyzeItemLabel: string;
   analyzeItemlabelEn: string;
   analyzeResultList: any;
+  analyzeResultListGeneral: any;
+  analyzeUnit: string;
 };
 
 export const BarGraph = (props: Props) => {
-  const { analyzeItemLabel, analyzeItemlabelEn, analyzeResultList } = props;
-  const [forcasedSpeed, setForcasedSpeed] = React.useState<number | null>(null);
-  const [forcasedBrankName, setForcasedBrankName] = React.useState<
-    string | null
-  >(null);
+  const {
+    analyzeItemLabel,
+    analyzeItemlabelEn,
+    analyzeResultList,
+    analyzeResultListGeneral,
+    analyzeUnit,
+  } = props;
 
   const [graphData, setGraphData] = React.useState<any>({
     labels: [],
@@ -89,16 +93,6 @@ export const BarGraph = (props: Props) => {
         position: "left" as const,
       },
     },
-    onHover: (_: any, activeElements: any) => {
-      if (activeElements.length > 0) {
-        const index = activeElements[0].index;
-        setForcasedSpeed(graphData.datasets[0].data[index]);
-        setForcasedBrankName(graphData.labels[index]);
-      } else {
-        setForcasedSpeed(null);
-        setForcasedBrankName(null);
-      }
-    },
   };
 
   return (
@@ -108,13 +102,16 @@ export const BarGraph = (props: Props) => {
         <Box sx={{ background: "#FFFDE7", borderRadius: 2, padding: "5px" }}>
           <Stack spacing={2} direction={"row"}>
             <Typography variant="h6" sx={{ fontWeight: "bold" }}>
-              {forcasedBrankName ? forcasedBrankName : "--"} 秒
+              {analyzeItemLabel} 全体
             </Typography>
             <Typography variant="h6">
-              速度：{forcasedSpeed ? forcasedSpeed : "--"}個/秒
+              {analyzeResultListGeneral !== null
+                ? analyzeResultListGeneral[0][analyzeItemlabelEn]
+                : "-"}
+              {analyzeUnit}
             </Typography>
-            <Typography variant="h6">前回比：+2.0個/秒</Typography>
-            <Typography variant="h6">平均比：+2.0個/秒</Typography>
+            <Typography variant="h6">平均比：+2.0{analyzeUnit}</Typography>
+            <Typography variant="h6">前回比：+2.0{analyzeUnit}</Typography>
           </Stack>
         </Box>
       </div>

--- a/src/components/features/analytics/BarGraph.tsx
+++ b/src/components/features/analytics/BarGraph.tsx
@@ -137,7 +137,7 @@ export const BarGraph = (props: Props) => {
                 : "-"}
               {analyzeUnit}
             </Typography>
-            <Typography variant="h6">前回比：---{analyzeUnit}</Typography>
+            <Typography variant="h6">前回比：+2.0{analyzeUnit}</Typography>
           </Stack>
         </Box>
       </div>

--- a/src/components/features/analytics/BarGraph.tsx
+++ b/src/components/features/analytics/BarGraph.tsx
@@ -19,7 +19,7 @@ ChartJS.register(
   LineElement,
   Title,
   Tooltip,
-  Legend
+  Legend,
 );
 
 type Props = {

--- a/src/components/features/analytics/Graph.tsx
+++ b/src/components/features/analytics/Graph.tsx
@@ -19,6 +19,8 @@ export const Graph = (props: Props) => {
   //それぞれの分析結果
   const [analyzeResultListInterval, setAnalyzeResultListInterval] =
     React.useState<any>(null);
+  const [analyzeResultListGeneral, setAnalyzeResultListGeneral] =
+    React.useState<any>(null);
   const [analyzeResultListPart, setAnalyzeResultListPart] =
     React.useState<any>(null);
 
@@ -34,46 +36,57 @@ export const Graph = (props: Props) => {
     {
       label: "データ数",
       labelEn: "datasCount",
+      unit: "個",
     },
     {
       label: "入力文字数",
       labelEn: "inputCharLength",
+      unit: "文字",
     },
     {
       label: "削除文字数",
       labelEn: "removedCharLength",
+      unit: "文字",
     },
     {
       label: "入力データ数",
       labelEn: "inputDataCount",
+      unit: "個",
     },
     {
       label: "削除データ数",
       labelEn: "removedDataCount",
+      unit: "個",
     },
     {
       label: "入力ミス率",
       labelEn: "missTypeRate",
+      unit: "%",
     },
     {
       label: "打鍵速度",
       labelEn: "typePerSec",
+      unit: "回/秒",
     },
     {
       label: "書き直し数",
       labelEn: "totalReInputCnt",
+      unit: "回",
     },
     {
       label: "合計書き直し時間",
       labelEn: "totalReInputTime",
+      unit: "秒",
     },
     {
       label: "書き直し率",
       labelEn: "reInputRate",
+      unit: "%",
     },
     {
       label: "平均書き直し時間",
       labelEn: "averageReInputTime",
+      unit: "秒",
     },
   ];
 
@@ -83,18 +96,27 @@ export const Graph = (props: Props) => {
       return;
     }
     if (selectedOption === "time") {
-      callAnalyzeApiWithInterval();
+      callAnalyzeApiWithInterval(10000, false);
+      const endTimestamp = sequence.at(-1)?.timestamp;
+      if (endTimestamp === undefined) {
+        return;
+      }
+      //全体の時間で分析を行う
+      callAnalyzeApiWithInterval(endTimestamp, true);
     } else if (selectedOption === "blank") {
       callAnalyzeApiWithPart();
     }
   }, [sequence, selectedOption]);
 
   //指定した時間間隔で分析を行うAPIを呼び出す
-  const callAnalyzeApiWithInterval = async () => {
+  const callAnalyzeApiWithInterval = async (
+    intervalTime: number,
+    isGeneral: boolean
+  ) => {
     const url = `${apiBaseUrl}/sequence/analyze/interval`;
 
     const obj = {
-      intervalTime: 10000,
+      intervalTime: intervalTime,
       sequence: sequence,
     };
 
@@ -119,7 +141,11 @@ export const Graph = (props: Props) => {
         }
         const data = await res.json();
         const analyzeResultList = data.analyzeResultList;
-        setAnalyzeResultListInterval(analyzeResultList);
+        if (!isGeneral) {
+          setAnalyzeResultListInterval(analyzeResultList);
+          return;
+        }
+        setAnalyzeResultListGeneral(analyzeResultList);
       });
     } catch (error) {
       alert("D: エラーが発生しました。");
@@ -174,6 +200,8 @@ export const Graph = (props: Props) => {
           analyzeItemLabel={analyzeItemList[selectedAnalyzedItem].label}
           analyzeItemlabelEn={analyzeItemList[selectedAnalyzedItem].labelEn}
           analyzeResultList={analyzeResultListInterval}
+          analyzeResultListGeneral={analyzeResultListGeneral}
+          analyzeUnit={analyzeItemList[selectedAnalyzedItem].unit}
         />
       ) : (
         <HorizoBarGraph

--- a/src/components/features/analytics/Graph.tsx
+++ b/src/components/features/analytics/Graph.tsx
@@ -228,6 +228,7 @@ export const Graph = (props: Props) => {
           analyzeItemLabel={analyzeItemList[selectedAnalyzedItem].label}
           analyzeItemlabelEn={analyzeItemList[selectedAnalyzedItem].labelEn}
           analyzeResultList={analyzeResultListPart}
+          analyzeUnit={analyzeItemList[selectedAnalyzedItem].unit}
         />
       )}
       <div>

--- a/src/components/features/analytics/Graph.tsx
+++ b/src/components/features/analytics/Graph.tsx
@@ -24,6 +24,25 @@ export const Graph = (props: Props) => {
   const [analyzeResultListPart, setAnalyzeResultListPart] =
     React.useState<any>(null);
 
+  //サンプルの分析結果平均
+  const analyzeResultListIntervalAverage = [
+    {
+      startTimestamp: 0,
+      endTimestamp: 10000,
+      datasCount: 10,
+      inputCharLength: 100,
+      removedCharLength: 10,
+      inputDataCount: 5,
+      removedDataCount: 2,
+      missTypeRate: 10,
+      typePerSec: 10,
+      totalReInputCnt: 5,
+      totalReInputTime: 10,
+      reInputRate: 10,
+      averageReInputTime: 2,
+    },
+  ];
+
   const handleOptionChange = (_: any, newValue: any) => {
     setSelectedOption(newValue);
   };
@@ -201,6 +220,7 @@ export const Graph = (props: Props) => {
           analyzeItemlabelEn={analyzeItemList[selectedAnalyzedItem].labelEn}
           analyzeResultList={analyzeResultListInterval}
           analyzeResultListGeneral={analyzeResultListGeneral}
+          analyzeResultListAverage={analyzeResultListIntervalAverage}
           analyzeUnit={analyzeItemList[selectedAnalyzedItem].unit}
         />
       ) : (

--- a/src/components/features/analytics/Graph.tsx
+++ b/src/components/features/analytics/Graph.tsx
@@ -130,7 +130,7 @@ export const Graph = (props: Props) => {
   //指定した時間間隔で分析を行うAPIを呼び出す
   const callAnalyzeApiWithInterval = async (
     intervalTime: number,
-    isGeneral: boolean
+    isGeneral: boolean,
   ) => {
     const url = `${apiBaseUrl}/sequence/analyze/interval`;
 

--- a/src/components/features/analytics/HorizoBarGraph.tsx
+++ b/src/components/features/analytics/HorizoBarGraph.tsx
@@ -22,7 +22,7 @@ ChartJS.register(
   BarElement,
   Title,
   Tooltip,
-  Legend,
+  Legend
 );
 
 type AnalyzeResultList = {
@@ -34,10 +34,16 @@ type Props = {
   analyzeItemLabel: string;
   analyzeItemlabelEn: string;
   analyzeResultList: AnalyzeResultList[] | null;
+  analyzeUnit: string;
 };
 
 export const HorizoBarGraph = (props: Props) => {
-  const { analyzeItemLabel, analyzeItemlabelEn, analyzeResultList } = props;
+  const {
+    analyzeItemLabel,
+    analyzeItemlabelEn,
+    analyzeResultList,
+    analyzeUnit,
+  } = props;
   const [forcasedSpeed, setForcasedSpeed] = React.useState<number | null>(null);
   const [forcasedBrankName, setForcasedBrankName] = React.useState<
     string | null
@@ -200,10 +206,11 @@ export const HorizoBarGraph = (props: Props) => {
               {forcasedBrankName ? forcasedBrankName : "--"}
             </Typography>
             <Typography variant="h6">
-              速度：{forcasedSpeed ? forcasedSpeed : "--"}個/秒
+              全体：{forcasedSpeed ? forcasedSpeed : "--"}
+              {analyzeUnit}
             </Typography>
-            <Typography variant="h6">前回比：+2.0個/秒</Typography>
-            <Typography variant="h6">平均比：+2.0個/秒</Typography>
+            <Typography variant="h6">平均比：+2.0{analyzeUnit}</Typography>
+            <Typography variant="h6">前回比：+2.0{analyzeUnit}</Typography>
           </Stack>
         </Box>
       </div>

--- a/src/components/features/analytics/HorizoBarGraph.tsx
+++ b/src/components/features/analytics/HorizoBarGraph.tsx
@@ -22,7 +22,7 @@ ChartJS.register(
   BarElement,
   Title,
   Tooltip,
-  Legend
+  Legend,
 );
 
 type AnalyzeResultList = {

--- a/src/components/features/exec/CodeCheckInput.tsx
+++ b/src/components/features/exec/CodeCheckInput.tsx
@@ -21,7 +21,7 @@ export const CodeCheckInput = (props: Props) => {
         <ReactCodeMirror
           value={code}
           extensions={[cppLanguage]}
-          style={{ fontSize: "14pt" }}
+          style={{ fontSize: "14pt", height: "400px", overflowY: "scroll" }}
         />
 
         <Typography variant="h6" sx={{ mt: 2, backgroundColor: "#e0e0e0" }}>


### PR DESCRIPTION
# 変更
* 時間ごとの分析では、全体の時間の平均値を計算して、黄色い部分に表示するようにした。
* フォーカスした時に表示単位を切り替えられるようにした。
* プログラムの結合結果で、縦がはみ出しそうな時はスクロールしてはみ出ないようにした。

# issue
closed #215 